### PR TITLE
Feature/tao 2794 delivery container service

### DIFF
--- a/install/RegisterDeliveryContainerService.php
+++ b/install/RegisterDeliveryContainerService.php
@@ -25,6 +25,9 @@ use oat\taoDeliveryRdf\model\DeliveryContainerService;
 use oat\oatbox\service\ServiceManager;
 
 /**
+ * Installation action that register the rdf implementation for the delivery container service
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 class RegisterDeliveryContainerService extends \common_ext_action_InstallAction
 {

--- a/install/RegisterDeliveryContainerService.php
+++ b/install/RegisterDeliveryContainerService.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+namespace oat\taoDeliveryRdf\install;
+
+use oat\taoDeliveryRdf\model\DeliveryContainerService;
+use oat\oatbox\service\ServiceManager;
+
+/**
+ */
+class RegisterDeliveryContainerService extends \common_ext_action_InstallAction
+{
+    /**
+     * @param $params
+     */
+    public function __invoke($params)
+    {
+        $serviceManager = ServiceManager::getServiceManager();
+
+        $deliveryContainerService = new DeliveryContainerService();
+        $deliveryContainerService->setServiceManager($serviceManager);
+        $serviceManager->register(DeliveryContainerService::CONFIG_ID, $deliveryContainerService);
+    }
+}
+

--- a/install/ontology/taodelivery.rdf
+++ b/install/ontology/taodelivery.rdf
@@ -80,6 +80,14 @@
     <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox"/>
     <tao:TAOGUIOrder><![CDATA[40]]></tao:TAOGUIOrder>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryPlugins">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Plugins]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Plugins associated to the delivery]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAODelivery.rdf#dDelivery"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <generis:is_language_dependent rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
+  </rdf:Description>
   
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryExecution">
     <rdfs:label xml:lang="en-US"><![CDATA[Delivery execution]]></rdfs:label>

--- a/install/update/Updater.php
+++ b/install/update/Updater.php
@@ -25,6 +25,7 @@ use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoDeliveryRdf\model\GroupAssignment;
 use oat\taoDelivery\model\AssignmentService;
+use oat\taoDeliveryRdf\install\RegisterDeliveryContainerService;
 
 /**
  * 
@@ -89,5 +90,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('1.5.0', '1.6.3');
+
+
+        if ($this->isVersion('1.6.3')) {
+
+            OntologyUpdater::syncModels();
+
+            $registerService = new RegisterDeliveryContainerService();
+            $registerService([]);
+
+            $this->setVersion('1.7.0');
+        }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -24,12 +24,12 @@ return array(
 	'label' => 'Delivery Management',
 	'description' => 'Manages deliveries using the ontology',
     'license' => 'GPL-2.0',
-    'version' => '1.6.3',
+    'version' => '1.7.0',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'taoGroups' => '>=2.7.1',
-        'taoTests' => '>=2.7.1',
-        'taoDelivery' => '>=3.0.0'
+        'taoTests' => '>=3.0.0',
+        'taoDelivery' => '>=4.3.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
     'acl' => array(
@@ -41,7 +41,8 @@ return array(
             __DIR__.DIRECTORY_SEPARATOR."install".DIRECTORY_SEPARATOR.'ontology'.DIRECTORY_SEPARATOR.'taodelivery.rdf'
         ),
         'php' => array(
-            __DIR__.DIRECTORY_SEPARATOR."install".DIRECTORY_SEPARATOR.'registerAssignment.php'
+            __DIR__.DIRECTORY_SEPARATOR."install".DIRECTORY_SEPARATOR.'registerAssignment.php',
+            'oat\\taoDeliveryRdf\\install\\RegisterDeliveryContainerService'
         )
     ),
     //'uninstall' => array(),

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -17,7 +17,7 @@
  * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
  */
 
-namespace oat\taoDelivery\model;
+namespace oat\taoDeliveryRdf\model;
 
 use common_ext_ExtensionManager as ExtensionsManager;
 use core_kernel_classes_Property;
@@ -37,17 +37,12 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
 
     const DELIVERY_PLUGINS_PROPERTY = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryPlugins';
 
-    private $pluginService;
 
-    public function __construct()
-    {
-        $this->pluginServie = $this->getServiceManager()->get(TestPluginService::CONFIG_ID);
-    }
-
-
-    public function getTestPlugins(DeliveryExecution $deliveryExecution)
+    public function getPlugins(DeliveryExecution $deliveryExecution)
     {
         $plugins = [];
+
+        $pluginServie = $this->getServiceManager()->get(TestPluginService::CONFIG_ID);
 
         $delivery = $deliveryExecution->getDelivery();
 
@@ -72,7 +67,7 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
         return $plugins;
     }
 
-    public function getBoostrap(DeliveryExecution $deliveryExecution)
+    public function getBootstrap(DeliveryExecution $deliveryExecution)
     {
         //FIXME this config is misplaced.
         $config = ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoDelivery\model;
+
+use common_ext_ExtensionManager as ExtensionsManager;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\service\ServiceManager;
+use oat\taoDelivery\model\AssignmentService;
+use oat\taoDelivery\model\DeliveryContainerService as DeliveryContainerServiceInterface;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoTests\model\runner\plugins\TestPluginService;
+
+/**
+ *
+ */
+class DeliveryContainerService  extends ConfigurableService implements DeliveryContainerServiceInterface
+{
+
+    const DELIVERY_PLUGINS_PROPERTY = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryPlugins';
+
+    private $pluginService;
+
+    public function __construct()
+    {
+        $this->pluginServie = $this->getServiceManager()->get(TestPluginService::CONFIG_ID);
+    }
+
+
+    public function getTestPlugins(DeliveryExecution $deliveryExecution)
+    {
+        $plugins = [];
+
+        $delivery = $deliveryExecution->getDelivery();
+
+        $pluginPropData = $delivery->getOnePropertyValue(new core_kernel_classes_Property(self::DELIVERY_PLUGINS_PROPERTY));
+
+        if(is_null($pluginPropData) || empty($pluginPropData)) {
+            //fallback to the default values
+            return $this->pluginService->getAllPlugins();
+        }
+
+        //otherwise decode the data from [ pluginId => active] to TestPlugins
+        $pluginList = json_decode($pluginPropData, true);
+        if(is_array($pluginList)){
+            foreach($pluginList as $id => $active){
+                $plugin = $this->pluginService->getPlugin($id);
+                if(!is_null($plugin)){
+                    $plugin->setActive((boolean) $active);
+                    $plugins[] = $plugin;
+                }
+            }
+        }
+        return $plugins;
+    }
+
+    public function getBoostrap(DeliveryExecution $deliveryExecution)
+    {
+        //FIXME this config is misplaced.
+        $config = ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
+        return $config['bootstrap'];
+    }
+
+
+    public function getTestDefinition(DeliveryExecution $execution)
+    {
+        //FIXME this shouldn't be a service call anymore
+        $delivery = $deliveryExecution->getDelivery();
+        $runtime = ServiceManager::getServiceManager()->get(AssignmentService::CONFIG_ID)->getRuntime($delivery);
+        $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+
+        return $inputParameters['QtiTestDefinition'];
+    }
+
+    public function getTestCompilation(DeliveryExecution $execution)
+    {
+
+        //FIXME this shouldn't be a service call anymore
+        $delivery = $deliveryExecution->getDelivery();
+        $runtime = ServiceManager::getServiceManager()->get(AssignmentService::CONFIG_ID)->getRuntime($delivery);
+        $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
+
+        return $inputParameters['QtiTestCompilation'];
+    }
+
+    public function setTestPlugins(core_kernel_classes_Resource $delivery, $plugins = [])
+    {
+        $pluginList = [];
+        foreach($plugins as $plugin){
+            if($plugin instanceof TestPlugin){
+                $pluginList[$plugin->getId()] = $plugin->isActive();
+            }
+        }
+        $delivery->editPropertyValue(new core_kernel_classes_Property(self::DELIVERY_PLUGINS_PROPERTY), json_encode($pluginList));
+    }
+}

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -30,14 +30,24 @@ use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoTests\models\runner\plugins\TestPluginService;
 
 /**
+ * RDF implementation for the Delivery container service.
+ * It means the container data are retrieved into the ontology.
  *
+ * TODO The actual implementation still uses serviceCall for the test definition and the test compilation
+ * and the config for the bootstrap. All those infos should be added during the assemble phase. 
+ *
+ * @author Bertrand Chevier <bertrand@taotesting.com>
  */
 class DeliveryContainerService  extends ConfigurableService implements DeliveryContainerServiceInterface
 {
 
     const DELIVERY_PLUGINS_PROPERTY = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryPlugins';
 
-
+    /**
+     * Get the list of plugins for the current execution
+     * @param DeliveryExecution $execution
+     * @return array the list of plugins
+     */
     public function getPlugins(DeliveryExecution $deliveryExecution)
     {
         $plugins = [];
@@ -67,17 +77,26 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
         return $plugins;
     }
 
+    /**
+     * Get the container bootstrap
+     * @param DeliveryExecution $execution
+     * @return string the bootstrap
+     */
     public function getBootstrap(DeliveryExecution $deliveryExecution)
     {
-        //FIXME this config is misplaced.
+        //FIXME this config is misplaced, this should be a delivery property
         $config = ExtensionsManager::singleton()->getExtensionById('taoQtiTest')->getConfig('testRunner');
         return $config['bootstrap'];
     }
 
-
+    /**
+     * Get the container testDefinition
+     * @param DeliveryExecution $execution
+     * @return string the testDefinition
+     */
     public function getTestDefinition(DeliveryExecution $deliveryExecution)
     {
-        //FIXME this shouldn't be a service call anymore
+        //FIXME this shouldn't be a service call anymore, a delivery property instead
         $delivery = $deliveryExecution->getDelivery();
         $runtime = ServiceManager::getServiceManager()->get(AssignmentService::CONFIG_ID)->getRuntime($delivery);
         $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());
@@ -85,10 +104,15 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
         return $inputParameters['QtiTestDefinition'];
     }
 
+    /**
+     * Get the container test compilation
+     * @param DeliveryExecution $execution
+     * @return string the  testCompilation
+     */
     public function getTestCompilation(DeliveryExecution $deliveryExecution)
     {
 
-        //FIXME this shouldn't be a service call anymore
+        //FIXME this shouldn't be a service call anymore, a delivery property instead
         $delivery = $deliveryExecution->getDelivery();
         $runtime = ServiceManager::getServiceManager()->get(AssignmentService::CONFIG_ID)->getRuntime($delivery);
         $inputParameters = \tao_models_classes_service_ServiceCallHelper::getInputValues($runtime, array());

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -19,7 +19,7 @@
 
 namespace oat\taoDeliveryRdf\model;
 
-use common_ext_ExtensionManager as ExtensionsManager;
+use common_ext_ExtensionsManager as ExtensionsManager;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\oatbox\service\ConfigurableService;
@@ -27,7 +27,7 @@ use oat\oatbox\service\ServiceManager;
 use oat\taoDelivery\model\AssignmentService;
 use oat\taoDelivery\model\DeliveryContainerService as DeliveryContainerServiceInterface;
 use oat\taoDelivery\model\execution\DeliveryExecution;
-use oat\taoTests\model\runner\plugins\TestPluginService;
+use oat\taoTests\models\runner\plugins\TestPluginService;
 
 /**
  *
@@ -42,7 +42,7 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
     {
         $plugins = [];
 
-        $pluginServie = $this->getServiceManager()->get(TestPluginService::CONFIG_ID);
+        $pluginService = $this->getServiceManager()->get(TestPluginService::CONFIG_ID);
 
         $delivery = $deliveryExecution->getDelivery();
 
@@ -50,7 +50,7 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
 
         if(is_null($pluginPropData) || empty($pluginPropData)) {
             //fallback to the default values
-            return $this->pluginService->getAllPlugins();
+            return $pluginService->getAllPlugins();
         }
 
         //otherwise decode the data from [ pluginId => active] to TestPlugins
@@ -75,7 +75,7 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
     }
 
 
-    public function getTestDefinition(DeliveryExecution $execution)
+    public function getTestDefinition(DeliveryExecution $deliveryExecution)
     {
         //FIXME this shouldn't be a service call anymore
         $delivery = $deliveryExecution->getDelivery();
@@ -85,7 +85,7 @@ class DeliveryContainerService  extends ConfigurableService implements DeliveryC
         return $inputParameters['QtiTestDefinition'];
     }
 
-    public function getTestCompilation(DeliveryExecution $execution)
+    public function getTestCompilation(DeliveryExecution $deliveryExecution)
     {
 
         //FIXME this shouldn't be a service call anymore


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-delivery/pull/191
Requires https://github.com/oat-sa/extension-tao-test/pull/133

The dependency issue delivery <-> taoQtiTest isn't yet resolved, but this is a 1st step. 
The service retrieve the data from the serviceCall and the config, but the next step will be to move those informations to the delivery model during the assemble phase. 