### PR TITLE
Feature/tao 4482 redesign test selector for delivery creation 2

### DIFF
--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -246,12 +246,18 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 //Filter tests which has no items
                 if (!empty($testItems)) {
                     $testUri = $test->getUri();
-                    $tests[] = ['id' => $testUri, 'uri' => $testUri, 'text' => $test->getLabel()];
+                    $tests[] = ['uri' => $testUri, 'label' => $test->getLabel()];
                 }
             } catch (\Exception $e) {
                 \common_Logger::w('Unable to load items for test ' . $testUri);
             }
         }
-        $this->returnJson(['total' => count($tests), 'items' => $tests]);
+        $this->returnJson([
+            'success' => true,
+            'data' => [
+                'total' => count($tests),
+                'range' => $tests
+            ]
+        ]);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -26,11 +26,11 @@ return array(
     'label'       => 'Delivery Management',
     'description' => 'Manages deliveries using the ontology',
     'license'     => 'GPL-2.0',
-    'version'     => '3.8.0',
+    'version'     => '3.9.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',
-        'tao'         => '>=10.26.0',
+        'tao'         => '>=12.13.0',
         'taoGroups'   => '>=2.7.1',
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',
-        'tao'         => '>=12.14.0',
+        'tao'         => '>=12.16.0',
         'taoGroups'   => '>=2.7.1',
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',
-        'tao'         => '>=12.13.0',
+        'tao'         => '>=12.14.0',
         'taoGroups'   => '>=2.7.1',
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -144,14 +144,15 @@ class Updater extends \common_ext_ExtensionUpdater {
             OntologyUpdater::syncModels();
             $this->setVersion('3.4.0');
         }
-       
+
         $this->skip('3.4.0', '3.6.1');
-      
+
         if ($this->isVersion('3.6.1')) {
             OntologyUpdater::syncModels();
             $this->getServiceManager()->register(RuntimeService::SERVICE_ID, new ContainerRuntime());
             $this->setVersion('3.7.0');
         }
-	$this->skip('3.7.0', '3.8.0');
+
+        $this->skip('3.7.0', '3.9.0');
     }
 }

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -18,7 +18,6 @@
 
 define([
     'jquery',
-    'lodash',
     'i18n',
     'core/dataProvider/request',
     'ui/feedback',
@@ -26,7 +25,6 @@ define([
     'ui/generis/widget/loader'
 ], function (
     $,
-    _,
     __,
     request,
     feedback,


### PR DESCRIPTION
Feature - TAO
Jira: https://oat-sa.atlassian.net/browse/TAO-4482

Requires:
- https://github.com/oat-sa/tao-core/pull/1450

Acceptance Criteria:
- I can quickly find my test on the list
- long lists of tests do not pose a problem

This pr utilizes the newly created ui/generis/widget/comboSearchBox from tao-core. There are two main use cases that this ticket tries to solve. 

First, a typical use case where a user only has a few tests and simply wants a quick way to find and select it. This is solved by adding all tests as a dropdown list.

Second, an Nccer use case, where a user has many (~ 2000) tests to select from. By adding a search bar to the dropdown list, the user will be able to filter the available tests.

#### To test
To help generate lots of tests, see this pull request: https://github.com/oat-sa/extension-tao-devtools/pull/100. Another possibility is to manipulate the returned data from `getAvailableTests`. You can clone the data as many times as you like to create a list of options as long as desired. Also, see tests created in tao-core pr.