### PR TITLE
Fix status value in getTaskStatus endpoint

### DIFF
--- a/controller/RestDelivery.php
+++ b/controller/RestDelivery.php
@@ -236,6 +236,23 @@ class RestDelivery extends \tao_actions_RestController
     }
 
     /**
+     * Return 'Success' instead of 'Completed', required by the specified API.
+     *
+     * @param TaskLogEntity $taskLogEntity
+     * @return string
+     */
+    protected function getTaskStatus(TaskLogEntity $taskLogEntity)
+    {
+        if ($taskLogEntity->getStatus()->isCreated()) {
+            return 'In Progress';
+        } else if ($taskLogEntity->getStatus()->isCompleted()){
+            return 'Success';
+        }
+
+        return $taskLogEntity->getStatus()->getLabel();
+    }
+
+    /**
      * @param TaskLogEntity $taskLogEntity
      * @return array
      */

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '3.17.1',
+  'version'     => '3.17.2',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -173,6 +173,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('3.17.0');
         }
         
-        $this->skip('3.17.0', '3.17.1');
+        $this->skip('3.17.0', '3.17.2');
     }
 }


### PR DESCRIPTION
The endpoint forces us to send back specific values for '**status**'. It is fixed now.