### PR TITLE
Feature/tao 5364 taskqueue ui component

### DIFF
--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -232,21 +232,9 @@ class DeliveryMgmt extends \tao_actions_SaSModule
             if ($myForm->isValid() && $myForm->isSubmited()) {
                 try {
                     $test = new core_kernel_classes_Resource($myForm->getValue('test'));
-                    $label = __("Delivery of %s", $test->getLabel());
                     $deliveryClass = new \core_kernel_classes_Class($myForm->getValue('classUri'));
-                    $deliveryResource = \core_kernel_classes_ResourceFactory::create($deliveryClass);
-                    $deliveryResource->setLabel($label);
-                    $values = $myForm->getValues();
 
-                    /** @var DeliveryFactory $deliveryFactoryResources */
-                    $deliveryFactoryResources = $this->getServiceManager()->get(DeliveryFactory::SERVICE_ID);
-                    $deliveryResource = $deliveryFactoryResources->setInitialProperties($values, $deliveryResource);
-
-                    $task = CompileDelivery::createTask($test, $deliveryClass, $deliveryResource);
-
-                    return $this->returnTaskJson($task, [
-                        'selectNode' => json_encode(\tao_helpers_Uri::encode($deliveryResource->getUri()))
-                    ]);
+                    return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass));
                 }catch(\Exception $e){
                     return $this->returnJson([
                         'success' => false,

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -244,10 +244,8 @@ class DeliveryMgmt extends \tao_actions_SaSModule
 
                     $task = CompileDelivery::createTask($test, $deliveryClass, $deliveryResource);
 
-                    $data = $this->getTaskLogReturnData($task->getId());
-                    return $this->returnJson([
-                        'success' => true,
-                        'data' => $data
+                    return $this->returnCreatedTaskJson($task->getId(), [
+                        'selectNode' => json_encode(\tao_helpers_Uri::encode($deliveryResource->getUri()))
                     ]);
                 }catch(\Exception $e){
                     return $this->returnJson([

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -244,7 +244,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
 
                     $task = CompileDelivery::createTask($test, $deliveryClass, $deliveryResource);
 
-                    return $this->returnCreatedTaskJson($task->getId(), [
+                    return $this->returnTaskJson($task, [
                         'selectNode' => json_encode(\tao_helpers_Uri::encode($deliveryResource->getUri()))
                     ]);
                 }catch(\Exception $e){

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -37,6 +37,7 @@ use oat\taoDeliveryRdf\model\NoTestsException;
 use oat\taoDeliveryRdf\view\form\DeliveryForm;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use common_report_Report as Report;
+use oat\taoPublishing\model\publishing\delivery\PublishingDeliveryService;
 use oat\taoTaskQueue\model\QueueDispatcher;
 use oat\taoTaskQueue\model\TaskLogInterface;
 use oat\taoTaskQueue\model\TaskLogActionTrait;
@@ -234,7 +235,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                     $test = new core_kernel_classes_Resource($myForm->getValue('test'));
                     $deliveryClass = new \core_kernel_classes_Class($myForm->getValue('classUri'));
 
-                    return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass));
+                    return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass, $myForm->getValues()));
                 }catch(\Exception $e){
                     return $this->returnJson([
                         'success' => false,

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -61,7 +61,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
     public function __construct()
     {
         parent::__construct();
-        
+
         // the service is initialized by default
         $this->service = DeliveryAssemblyService::singleton();
         $this->defaultData();
@@ -75,7 +75,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
     {
         return $this->service;
     }
-    
+
     /*
      * controller actions
      */
@@ -118,11 +118,11 @@ class DeliveryMgmt extends \tao_actions_SaSModule
         }
         $formContainer = new DeliveryForm($class, $delivery);
         $myForm = $formContainer->getForm();
-        
+
         if ($myForm->isSubmited()) {
             if ($myForm->isValid()) {
                 $propertyValues = $myForm->getValues();
-                
+
                 // then save the property values as usual
                 $binder = new \tao_models_classes_dataBinding_GenerisFormDataBinder($delivery);
                 $delivery = $binder->bind($propertyValues);
@@ -134,26 +134,26 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 $this->setData('reload', true);
             }
         }
-        
+
         $this->setData('label', $delivery->getLabel());
-        
+
         // history
         $this->setData('date', $this->getClassService()->getCompilationDate($delivery));
         if (ServiceProxy::singleton()->implementsMonitoring()) {
             $execs = ServiceProxy::singleton()->getExecutionsByDelivery($delivery);
             $this->setData('exec', count($execs));
         }
-        
+
         // define the groups related to the current delivery
         $property = new core_kernel_classes_Property(GroupAssignment::PROPERTY_GROUP_DELIVERY);
         $tree = \tao_helpers_form_GenerisTreeForm::buildReverseTree($delivery, $property);
         $tree->setTitle(__('Assigned to'));
         $tree->setTemplate(Template::getTemplate('widgets/assignGroup.tpl'));
         $this->setData('groupTree', $tree->render());
-        
+
         // testtaker brick
         $this->setData('assemblyUri', $delivery->getUri());
-        
+
         // define the subjects excluded from the current delivery
         $property = new core_kernel_classes_Property(DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS);
         $excluded = $delivery->getPropertyValues($property);
@@ -165,26 +165,26 @@ class DeliveryMgmt extends \tao_actions_SaSModule
 
         $this->setData('formTitle', __('Properties'));
         $this->setData('myForm', $myForm->render());
-        
+
         if (\common_ext_ExtensionsManager::singleton()->isEnabled('taoCampaign')) {
             $this->setData('campaign', taoCampaign_helpers_Campaign::renderCampaignTree($delivery));
         }
         $this->setView('DeliveryMgmt/editDelivery.tpl');
     }
-    
+
     public function excludeTesttaker()
     {
         $assembly = $this->getCurrentInstance();
         $this->setData('assemblyUri', $assembly->getUri());
-        
+
         // define the subjects excluded from the current delivery
         $property = new core_kernel_classes_Property(DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS);
-        $excluded = array(); 
+        $excluded = array();
         foreach ($assembly->getPropertyValues($property) as $uri) {
             $user = new core_kernel_classes_Resource($uri);
             $excluded[$uri] = $user->getLabel();
         }
-        
+
         $assigned = array();
         foreach ($this->getServiceManager()->get(AssignmentService::SERVICE_ID)->getAssignedUsers($assembly->getUri()) as $userId) {
             if (!in_array($userId, array_keys($excluded))) {
@@ -192,14 +192,14 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 $assigned[$userId] = $user->getLabel();
             }
         }
-        
+
         $this->setData('assigned', $assigned);
         $this->setData('excluded', $excluded);
-        
-        
+
+
         $this->setView('DeliveryMgmt/excludeTesttaker.tpl');
     }
-    
+
     public function saveExcluded() {
         if(!\tao_helpers_Request::isAjax()){
             throw new \common_exception_IsAjaxAction(__FUNCTION__);
@@ -207,12 +207,12 @@ class DeliveryMgmt extends \tao_actions_SaSModule
         if(!$this->hasRequestParameter('excluded')){
             throw new \common_exception_MissingParameter('excluded');
         }
-        
+
         $jsonArray = json_decode($_POST['excluded']);
         if(!is_array($jsonArray)){
             throw new \common_Exception('parameter "excluded" should be a json encoded array');
         }
-        
+
         $assembly = $this->getCurrentInstance();
         $success = $assembly->editPropertyValues(new core_kernel_classes_Property(DeliveryContainerService::PROPERTY_EXCLUDED_SUBJECTS),$jsonArray);
 
@@ -228,7 +228,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
         try {
             $formContainer = new WizardForm(array('class' => $this->getCurrentClass()));
             $myForm = $formContainer->getForm();
-             
+
             if ($myForm->isValid() && $myForm->isSubmited()) {
                 try {
                     $test = new core_kernel_classes_Resource($myForm->getValue('test'));
@@ -244,10 +244,10 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 }
             } else {
                 $this->setData('myForm', $myForm->render());
-                $this->setData('formTitle', __('Create a new delivery'));
+                $this->setData('formTitle', __('Publish a new delivery'));
                 $this->setView('form.tpl', 'tao');
             }
-    
+
         } catch (NoTestsException $e) {
             $this->setView('DeliveryMgmt/wizard_error.tpl');
         }

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -244,7 +244,7 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 }
             } else {
                 $this->setData('myForm', $myForm->render());
-                $this->setData('formTitle', __('Publish a new delivery'));
+                $this->setData('formTitle', __('Create a new delivery'));
                 $this->setView('form.tpl', 'tao');
             }
 

--- a/controller/RestDelivery.php
+++ b/controller/RestDelivery.php
@@ -103,16 +103,12 @@ class RestDelivery extends \tao_actions_RestController
             }
 
             $deliveryClass = $this->getDeliveryClassByParameters();
-            $deliveryResource = \core_kernel_classes_ResourceFactory::create($deliveryClass);
-            $label = __("Delivery of %s", $test->getLabel());
-            $deliveryResource->setLabel($label);
 
             /** @var DeliveryFactory $deliveryFactoryService */
             $deliveryFactoryService = $this->getServiceManager()->get(DeliveryFactory::SERVICE_ID);
             $initialProperties = $deliveryFactoryService->getInitialPropertiesFromRequest($this->getRequest());
-            $deliveryResource = $deliveryFactoryService->setInitialProperties($initialProperties, $deliveryResource);
 
-            $task = CompileDelivery::createTask($test, $deliveryClass, $deliveryResource);
+            $task = CompileDelivery::createTask($test, $deliveryClass, $initialProperties);
 
             $result = [
                 'reference_id' => $task->getId()
@@ -132,7 +128,6 @@ class RestDelivery extends \tao_actions_RestController
             }
 
             return $this->returnSuccess($result);
-
         } catch (\Exception $e) {
             $this->returnFailure($e);
         }

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',
         'taoDelivery' => '>=7.4.0',
-        'taoTaskQueue' => '>=0.9.0'
+        'taoTaskQueue' => '>=0.10.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '3.17.2',
+  'version'     => '3.18.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',
@@ -36,7 +36,7 @@ return array(
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',
         'taoDelivery' => '>=7.4.0',
-        'taoTaskQueue' => '>=0.4.0'
+        'taoTaskQueue' => '>=0.7.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
         'taoTests'    => '>=3.5.0',
         'taoQtiTest'  => '>=9.11.0',
         'taoDelivery' => '>=7.4.0',
-        'taoTaskQueue' => '>=0.8.0'
+        'taoTaskQueue' => '>=0.9.0'
     ),
 	'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
     'acl' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -21,6 +21,7 @@
 use oat\taoDeliveryRdf\install\RegisterDeliveryFactoryService;
 use oat\taoDeliveryRdf\install\RegisterDeliveryPublishingService;
 use oat\taoDeliveryRdf\scripts\install\OverrideRuntime;
+use oat\taoDeliveryRdf\scripts\install\SetUpQueueTasks;
 
 return array(
   'name'        => 'taoDeliveryRdf',
@@ -53,7 +54,8 @@ return array(
             'oat\\taoDeliveryRdf\\install\\RegisterDeliveryContainerService',
             'oat\\taoDeliveryRdf\\scripts\\RegisterEvents',
             RegisterDeliveryFactoryService::class,
-            OverrideRuntime::class
+            OverrideRuntime::class,
+            SetUpQueueTasks::class
         )
     ),
     //'uninstall' => array(),

--- a/model/tasks/CompileDelivery.php
+++ b/model/tasks/CompileDelivery.php
@@ -53,8 +53,8 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable
 
         \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf');
 
-        if (isset($params['$deliveryClass'])) {
-            $deliveryClass = new \core_kernel_classes_Class($params['$deliveryClass']);
+        if (isset($params['deliveryClass'])) {
+            $deliveryClass = new \core_kernel_classes_Class($params['deliveryClass']);
             if (!$deliveryClass->exists()) {
                 $deliveryClass = new \core_kernel_classes_Class(DeliveryAssemblyService::CLASS_URI);
             }

--- a/model/tasks/CompileDelivery.php
+++ b/model/tasks/CompileDelivery.php
@@ -99,6 +99,6 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable
             $parameters['delivery'] = $delivery->getUri();
         }
 
-        return $queueDispatcher->createTask($action, $parameters, 'Compilation of ' . $test->getLabel());
+        return $queueDispatcher->createTask($action, $parameters, __('Publishing of "%s"', $test->getLabel()));
     }
 }

--- a/scripts/install/SetUpQueueTasks.php
+++ b/scripts/install/SetUpQueueTasks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+namespace oat\taoDeliveryRdf\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoDeliveryRdf\model\tasks\CompileDelivery;
+use oat\taoTaskQueue\model\TaskLogInterface;
+
+/**
+ * Install Action to set up things related to the task queue
+ *
+ * @author Gyula Szucs <gyula@taotesting.com>
+ */
+class SetUpQueueTasks extends InstallAction
+{
+    public function __invoke($params)
+    {
+        /** @var TaskLogInterface|ConfigurableService $taskLogService */
+        $taskLogService = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
+
+        $taskLogService->linkTaskToCategory(CompileDelivery::class, TaskLogInterface::CATEGORY_DELIVERY_COMPILATION);
+
+        $this->registerService(TaskLogInterface::SERVICE_ID, $taskLogService);
+
+        return \common_report_Report::createSuccess('Task(s) successfully set up.');
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -20,6 +20,7 @@
  */
 namespace oat\taoDeliveryRdf\scripts\update;
 
+use oat\oatbox\service\ConfigurableService;
 use oat\tao\scripts\update\OntologyUpdater;
 use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\accessControl\func\AccessRule;
@@ -178,7 +179,7 @@ class Updater extends \common_ext_ExtensionUpdater {
         $this->skip('3.17.0', '3.17.3');
 
         if ($this->isVersion('3.17.3')) {
-            /** @var TaskLogInterface $taskLogService */
+            /** @var TaskLogInterface|ConfigurableService $taskLogService */
             $taskLogService = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
 
             $taskLogService->linkTaskToCategory(CompileDelivery::class, TaskLogInterface::CATEGORY_DELIVERY_COMPILATION);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -29,9 +29,11 @@ use oat\taoDeliveryRdf\model\DeliveryPublishing;
 use oat\taoDeliveryRdf\model\GroupAssignment;
 use oat\taoDelivery\model\AssignmentService;
 use oat\taoDeliveryRdf\install\RegisterDeliveryContainerService;
+use oat\taoDeliveryRdf\model\tasks\CompileDelivery;
 use oat\taoDeliveryRdf\scripts\RegisterEvents;
 use oat\taoDeliveryRdf\model\ContainerRuntime;
 use oat\taoDelivery\model\RuntimeService;
+use oat\taoTaskQueue\model\TaskLogInterface;
 
 /**
  *
@@ -174,5 +176,16 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
         
         $this->skip('3.17.0', '3.17.2');
+
+        if ($this->isVersion('3.17.2')) {
+            /** @var TaskLogInterface $taskLogService */
+            $taskLogService = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
+
+            $taskLogService->linkTaskToCategory(CompileDelivery::class, TaskLogInterface::CATEGORY_DELIVERY_COMPILATION);
+
+            $this->getServiceManager()->register(TaskLogInterface::SERVICE_ID, $taskLogService);
+
+            $this->setVersion('3.18.0');
+        }
     }
 }

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
-define(['jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'core/promise'], function ($, __, filterFactory, feedback, urlUtils, Promise) {
+define(['lodash', 'jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'core/promise', 'ui/report', 'taoTaskQueue/model/taskQueue', 'layout/loading-bar'], function (_, $, __, filterFactory, feedback, urlUtils, Promise, report, taskQueue, loadingBar) {
     'use strict';
 
     var provider = {
@@ -48,11 +48,16 @@ define(['jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'core/promise'
         }
     };
 
+    var submitter = {
+
+    };
 
     return {
         start: function () {
             var $filterContainer = $('.test-select-container');
             var $formElement = $('#test');
+            var $form = $('#simpleWizard');
+            var $container = $form.closest('.content-block');
 
             filterFactory($filterContainer, {
                 placeholder: __('Select the test you want to publish to the test-takers'),
@@ -72,6 +77,45 @@ define(['jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'core/promise'
                         feedback().error(err);
                     });
             }).render('<%= text %>');
+
+            $form.on('submit', function(e){
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                loadingBar.start();
+
+                //pause polling all status during creation process to prevent concurrency issue
+                taskQueue.pollAllStop();
+                taskQueue.create($form.prop('action'), $form.serializeArray()).then(function(result){
+                    var task = result.task;
+                    if(result.finished){
+                        //finished quickly display report
+                        report({replace:true}, task.report.children[0]).render($container);
+                        taskQueue.pollAll(true);
+                    }else{
+                        //move this to the queue
+                        report({replace:true}, {
+                            type: 'info',
+                            message : '<strong>"'+task.taskLabel+'"</strong> takes a long time to execute so it has been moved to the background.'
+                        }).render($container);
+
+                        _.delay(function(){
+                            taskQueue.trigger('taskcreated', task);
+                            taskQueue.pollAll(true);
+                        }, 600);
+                    }
+                    loadingBar.stop();
+                }).catch(function(err){
+                    taskQueue.pollAll();
+                    feedback().error(err);
+                });
+            });
+
+            return;
+            $form.find('.form-submitter').on('click', function(e){
+                e.preventDefault();
+
+                console.log($form.serializeArray());
+            });
         }
     };
 });

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -27,7 +27,7 @@ define([
     'layout/section',
     'core/promise',
     'taoTaskQueue/model/taskQueue',
-    'taoTaskQueue/component/taskCreationButton/taskCreationButton'
+    'taoTaskQueue/component/button/standardButton'
 ], function (_, $, __, uriHelper, filterFactory, feedback, urlUtils, section, Promise, taskQueue, taskCreationButtonFactory) {
     'use strict';
 
@@ -79,7 +79,7 @@ define([
             var $formElement = $('#test');
             var $form = $('#simpleWizard');
             var $container = $form.closest('.content-block');
-            var button, $oldSubmitter;
+            var taskCreationButton, $oldSubmitter;
 
             filterFactory($filterContainer, {
                 placeholder: __('Select the test you want to publish to the test-takers'),
@@ -89,9 +89,9 @@ define([
             }).on('change', function (test) {
                 $formElement.val(test);
                 if(test){
-                    button.enable();
+                    taskCreationButton.enable();
                 }else{
-                    button.disable();
+                    taskCreationButton.disable();
                 }
             }).on('request', function (params) {
                 provider
@@ -107,19 +107,17 @@ define([
 
             //find the old submitter and replace it with the new component
             $oldSubmitter = $form.find('.form-submitter');
-            button = taskCreationButtonFactory({
+            taskCreationButton = taskCreationButtonFactory({
                 type : 'info',
                 icon : 'delivery',
                 title : __('Publish the test'),
                 label : __('Publish'),
-                terminatedLabel: __('Moved to background'),
                 taskQueue : taskQueue,
-                reportContainer : $container,
-                sourceElement : $form,
-                requestUrl : $form.prop('action'),
-                getRequestData : function getRequestData(){
+                taskCreationtUrl : $form.prop('action'),
+                taskCreationData : function getTaskCreationData(){
                     return $form.serializeArray();
-                }
+                },
+                taskReportContainer : $container
             }).on('finished', function(result){
                 if (result.task
                     && result.task.report
@@ -142,7 +140,7 @@ define([
             }).render($oldSubmitter.closest('.form-toolbar')).disable();
 
             //replace the old submitter with the new one and apply its style
-            $oldSubmitter.replaceWith(button.getElement().css({float: 'right'}));
+            $oldSubmitter.replaceWith(taskCreationButton.getElement().css({float: 'right'}));
         }
     };
 });

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -106,7 +106,7 @@ define([
                 }
             }).on('continue', function(result){
                 if (result.extra && result.extra.selectNode) {
-                    //old jstree API used to refresh the the tree:
+                    //old jstree API used to refresh the tree:
                     $('.tree').trigger('refresh.taotree', [{
                         uri: result.extra.selectNode
                     }]);
@@ -116,7 +116,7 @@ define([
                 feedback().error(err);
             }).render($oldSubmitter.closest('.form-toolbar')).disable();
 
-            //replace the old submitter with the new one
+            //replace the old submitter with the new one and apply its style
             $oldSubmitter.replaceWith(button.getElement().css({float: 'right'}));
         }
     };

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -113,7 +113,7 @@ define([
                 title : __('Publish the test'),
                 label : __('Publish'),
                 taskQueue : taskQueue,
-                taskCreationtUrl : $form.prop('action'),
+                taskCreationUrl : $form.prop('action'),
                 taskCreationData : function getTaskCreationData(){
                     return $form.serializeArray();
                 },

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -72,6 +72,11 @@ define([
                 label: __('Select the test')
             }).on('change', function (test) {
                 $formElement.val(test);
+                if(test){
+                    button.enable();
+                }else{
+                    button.disable();
+                }
             }).on('request', function (params) {
                 provider
                     .list(params.data)
@@ -109,7 +114,7 @@ define([
             }).on('error', function(err){
                 //format and display error message to user
                 feedback().error(err);
-            }).render($oldSubmitter.closest('.form-toolbar'));
+            }).render($oldSubmitter.closest('.form-toolbar')).disable();
 
             //replace the old submitter with the new one
             $oldSubmitter.replaceWith(button.getElement().css({float: 'right'}));

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -48,10 +48,6 @@ define(['lodash', 'jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'cor
         }
     };
 
-    var submitter = {
-
-    };
-
     return {
         start: function () {
             var $filterContainer = $('.test-select-container');
@@ -90,7 +86,9 @@ define(['lodash', 'jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'cor
                     if(result.finished){
                         //finished quickly display report
                         report({replace:true}, task.report.children[0]).render($container);
-                        taskQueue.pollAll(true);
+                        taskQueue.archive(task.id).then(function(){
+                            taskQueue.pollAll();
+                        });
                     }else{
                         //move this to the queue
                         report({replace:true}, {
@@ -108,13 +106,6 @@ define(['lodash', 'jquery', 'i18n', 'ui/filter', 'ui/feedback', 'util/url', 'cor
                     taskQueue.pollAll();
                     feedback().error(err);
                 });
-            });
-
-            return;
-            $form.find('.form-submitter').on('click', function(e){
-                e.preventDefault();
-
-                console.log($form.serializeArray());
             });
         }
     };


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-task-queue/pull/33

Integrates the new task queue management to delivery compilation.
The main changes affects the controller `views/js/controller/DeliveryMgmt/wizard.js` and the way the request is communicated to the server and is processed back.