### PR TITLE
Fix/fixed parameters for compile task

### DIFF
--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -234,8 +234,10 @@ class DeliveryMgmt extends \tao_actions_SaSModule
                 try {
                     $test = new core_kernel_classes_Resource($myForm->getValue('test'));
                     $deliveryClass = new \core_kernel_classes_Class($myForm->getValue('classUri'));
-
-                    return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass, $myForm->getValues()));
+                    /** @var DeliveryFactory $deliveryFactoryResources */
+                    $deliveryFactoryResources = $this->getServiceManager()->get(DeliveryFactory::SERVICE_ID);
+                    $initialProperties = $deliveryFactoryResources->getInitialPropertiesFromArray($myForm->getValues());
+                    return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass, $initialProperties));
                 }catch(\Exception $e){
                     return $this->returnJson([
                         'success' => false,

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '3.19.1',
+  'version'     => '3.19.2',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=3.36.0',

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -169,6 +169,22 @@ class DeliveryFactory extends ConfigurableService
     }
 
     /**
+     * @param array $properties
+     * @return array
+     */
+    public function getInitialPropertiesFromArray($properties)
+    {
+        $initialProperties = $this->getOption(self::OPTION_INITIAL_PROPERTIES);
+        $initialPropertiesResponse = [];
+        foreach ($properties as $uri => $value) {
+            if (in_array($uri, $initialProperties) && $value) {
+                $initialPropertiesResponse[$uri] = $value;
+            }
+        }
+        return $initialPropertiesResponse;
+    }
+
+    /**
      * Create a delivery resource based on a successfull compilation
      *
      * @param core_kernel_classes_Class $deliveryClass

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -201,6 +201,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('3.19.0');
         }
 
-        $this->skip('3.19.0', '3.19.1');
+        $this->skip('3.19.0', '3.19.2');
     }
 }


### PR DESCRIPTION
$myForm->getValues() return a lot of unnecessary data. getInitialPropertiesFromArray prepare data for task.