### PR TITLE
Feature/tao 6922 hide test dates

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '7.1.0',
+  'version'     => '7.2.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '6.0.0',
+  'version'     => '6.1.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '6.1.0',
+  'version'     => '7.1.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/model/AssignmentFactory.php
+++ b/model/AssignmentFactory.php
@@ -113,7 +113,6 @@ class AssignmentFactory implements ServiceLocatorAwareInterface
     {
         $descriptions = array();
 
-        \common_Logger::i('display dates? ' . ($this->displayDates ? 'on' : 'off'));
         if ($this->displayDates) {
             if (!empty($startTime) && !empty($endTime)) {
                 $descriptions[] = __('Available from %1$s to %2$s',

--- a/model/AssignmentFactory.php
+++ b/model/AssignmentFactory.php
@@ -44,12 +44,15 @@ class AssignmentFactory implements ServiceLocatorAwareInterface
 
     private $displayAttempts;
 
-    public function __construct(\core_kernel_classes_Resource $delivery, User $user, $startable, $displayAttempts = true)
+    private $displayDates;
+
+    public function __construct(\core_kernel_classes_Resource $delivery, User $user, $startable, $displayAttempts = true, $displayDates = true)
     {
         $this->delivery = $delivery;
         $this->user = $user;
         $this->startable = $startable;
         $this->displayAttempts = $displayAttempts;
+        $this->displayDates = $displayDates;
     }
     
     public function getDeliveryId()
@@ -109,15 +112,18 @@ class AssignmentFactory implements ServiceLocatorAwareInterface
     protected function buildDescriptionFromData($startTime, $endTime, $countExecs, $maxExecs)
     {
         $descriptions = array();
-        if (!empty($startTime) && !empty($endTime)) {
-            $descriptions[] = __('Available from %1$s to %2$s',
-                tao_helpers_Date::displayeDate($startTime)
-                ,tao_helpers_Date::displayeDate($endTime)
-            );
-        } elseif (!empty($startTime) && empty($endTime)) {
-            $descriptions[] = __('Available from %s', tao_helpers_Date::displayeDate($startTime));
-        } elseif (!empty($endTime)) {
-            $descriptions[] = __('Available until %s', tao_helpers_Date::displayeDate($endTime));
+
+        if ($this->displayDates) {
+            if (!empty($startTime) && !empty($endTime)) {
+                $descriptions[] = __('Available from %1$s to %2$s',
+                    tao_helpers_Date::displayeDate($startTime)
+                    ,tao_helpers_Date::displayeDate($endTime)
+                );
+            } elseif (!empty($startTime) && empty($endTime)) {
+                $descriptions[] = __('Available from %s', tao_helpers_Date::displayeDate($startTime));
+            } elseif (!empty($endTime)) {
+                $descriptions[] = __('Available until %s', tao_helpers_Date::displayeDate($endTime));
+            }    
         }
         
         if ($maxExecs != 0 && $this->displayAttempts) {

--- a/model/AssignmentFactory.php
+++ b/model/AssignmentFactory.php
@@ -113,6 +113,7 @@ class AssignmentFactory implements ServiceLocatorAwareInterface
     {
         $descriptions = array();
 
+        \common_Logger::i('display dates? ' . ($this->displayDates ? 'on' : 'off'));
         if ($this->displayDates) {
             if (!empty($startTime) && !empty($endTime)) {
                 $descriptions[] = __('Available from %1$s to %2$s',

--- a/model/GroupAssignment.php
+++ b/model/GroupAssignment.php
@@ -46,6 +46,8 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
 
     const DISPLAY_ATTEMPTS_OPTION = 'display_attempts';
 
+    const DISPLAY_DATES_OPTION = false;//'display_dates';
+
     /**
      * (non-PHPdoc)
      * @see \oat\taoDelivery\model\AssignmentService::getAssignments()
@@ -70,19 +72,22 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
 
         $displayAttempts = ($this->hasOption(self::DISPLAY_ATTEMPTS_OPTION)) ? $this->getOption(self::DISPLAY_ATTEMPTS_OPTION) : true;
 
+        $displayDates = ($this->hasOption(self::DISPLAY_DATES_OPTION)) ? $this->getOption(self::DISPLAY_DATES_OPTION) : true;
+
         if ($this->isDeliveryGuestUser($user)) {
             foreach ($this->getGuestAccessDeliveries() as $id) {
                 $delivery = new \core_kernel_classes_Resource($id);
                 $startable = $this->verifyTime($delivery) && $this->verifyToken($delivery, $user);
-                $assignments[] = $this->getAssignmentFactory($delivery, $user, $startable, $displayAttempts);
+                $assignments[] = $this->getAssignmentFactory($delivery, $user, $startable, $displayAttempts, $displayDates);
             }
         } else {
             foreach ($this->getDeliveryIdsByUser($user) as $id) {
                 $delivery = new \core_kernel_classes_Resource($id);
                 $startable = $this->verifyTime($delivery) && $this->verifyToken($delivery, $user);
-                $assignments[] = $this->getAssignmentFactory($delivery, $user, $startable, $displayAttempts);
+                $assignments[] = $this->getAssignmentFactory($delivery, $user, $startable, $displayAttempts, $displayDates);
             }
         }
+        \common_Logger::i($assignments);
         return $assignments;
     }
 
@@ -341,9 +346,10 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
      * @param bool $displayAttempts
      * @return AssignmentFactory
      */
-    protected function getAssignmentFactory(\core_kernel_classes_Resource $delivery, User $user, $startable, $displayAttempts = true)
+    protected function getAssignmentFactory(\core_kernel_classes_Resource $delivery, User $user, $startable, $displayAttempts = true, $displayDates = true)
     {
-        $factory = new AssignmentFactory($delivery, $user, $startable, $displayAttempts);
+        \common_Logger::i($displayDates);
+        $factory = new AssignmentFactory($delivery, $user, $startable, $displayAttempts, $displayDates);
         $factory->setServiceLocator($this->getServiceLocator());
         return $factory;
     }

--- a/model/GroupAssignment.php
+++ b/model/GroupAssignment.php
@@ -46,7 +46,7 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
 
     const DISPLAY_ATTEMPTS_OPTION = 'display_attempts';
 
-    const DISPLAY_DATES_OPTION = false;//'display_dates';
+    const DISPLAY_DATES_OPTION = 'display_dates';
 
     /**
      * (non-PHPdoc)
@@ -87,7 +87,6 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
                 $assignments[] = $this->getAssignmentFactory($delivery, $user, $startable, $displayAttempts, $displayDates);
             }
         }
-        \common_Logger::i($assignments);
         return $assignments;
     }
 
@@ -348,7 +347,6 @@ class GroupAssignment extends ConfigurableService implements AssignmentService
      */
     protected function getAssignmentFactory(\core_kernel_classes_Resource $delivery, User $user, $startable, $displayAttempts = true, $displayDates = true)
     {
-        \common_Logger::i($displayDates);
         $factory = new AssignmentFactory($delivery, $user, $startable, $displayAttempts, $displayDates);
         $factory->setServiceLocator($this->getServiceLocator());
         return $factory;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -235,6 +235,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.2.2');
         }
 
-        $this->skip('5.2.2', '6.0.0');
+        $this->skip('5.2.2', '6.1.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -235,6 +235,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.2.2');
         }
 
-        $this->skip('5.2.2', '6.1.0');
+        $this->skip('5.2.2', '7.1.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -244,8 +244,8 @@ class Updater extends \common_ext_ExtensionUpdater {
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
             $eventManager->attach(DeliveryExecutionReactivated::class, [SessionStateHelper::class, 'onExecutionReactivation']);
             $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
-            $this->setVersion('7.2.0');
+            $this->setVersion('7.0.0');
         }
-        $this->skip('7.2.0', '7.2.1');
+        $this->skip('7.0.0', '7.2.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -244,9 +244,9 @@ class Updater extends \common_ext_ExtensionUpdater {
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
             $eventManager->attach(DeliveryExecutionReactivated::class, [SessionStateHelper::class, 'onExecutionReactivation']);
             $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
-            $this->setVersion('7.1.0');
+            $this->setVersion('7.2.0');
         }
-        $this->skip('7.0.0', '7.0.1');
+        $this->skip('7.2.0', '7.2.1');
 
     }
 }


### PR DESCRIPTION
For https://oat-sa.atlassian.net/browse/TAO-6922
and depends on the same-named branch in https://github.com/oat-sa/extension-tao-invalsi to have any effect.

Test dates will not be shown to a test-taker if the `display_dates` option has been set to false (by a new install script in Invalsi).