### PR TITLE
TAO-7282 Fixed delivery theme id retrieval from DB upon delivery launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+vendor/

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '7.4.1',
+  'version'     => '7.4.2',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.0.0');
         }
         
-        $this->skip('7.0.0', '7.4.1');
+        $this->skip('7.0.0', '7.4.2');
     }
 }


### PR DESCRIPTION
Theme ID can be null, when there is no theme selected, however 'common_persistence_KvDriver' implementations return false upon failed 'get' calls.