### PR TITLE
Create new session when delivery compilation is done from CLI

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '7.4.1',
+  'version'     => '7.4.2',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '7.4.2',
+  'version'     => '7.4.3',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/model/tasks/CompileDelivery.php
+++ b/model/tasks/CompileDelivery.php
@@ -25,6 +25,7 @@ use common_report_Report as Report;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\extension\AbstractAction;
 use oat\oatbox\service\ServiceManager;
+use oat\tao\model\session\PretenderSession;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
 use oat\tao\model\taskQueue\Task\TaskAwareTrait;
@@ -72,6 +73,7 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable, TaskA
         $label = 'Delivery of ' . $test->getLabel();
 
         $deliveryResource =  \core_kernel_classes_ResourceFactory::create($deliveryClass);
+
         if ($params['initialProperties']) {
             // Setting "Sync to remote..." if enabled
             /** @var DeliveryFactory $deliveryFactoryResources */
@@ -88,6 +90,11 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable, TaskA
         if (!is_null($task)) {
             $deliveryCompileTaskProperty = $this->getProperty(DeliveryFactory::PROPERTY_DELIVERY_COMPILE_TASK);
             $deliveryResource->setPropertyValue($deliveryCompileTaskProperty, $task->getId());
+
+            if (\common_session_SessionManager::isAnonymous() && $task->getMetadata(TaskInterface::JSON_METADATA_OWNER_KEY)) {
+                $userResource = new \core_kernel_classes_Resource($task->getMetadata(TaskInterface::JSON_METADATA_OWNER_KEY));
+                \common_session_SessionManager::startSession(new PretenderSession(new \core_kernel_users_GenerisUser($userResource)));
+            }
         }
 
         /** @var DeliveryFactory $deliveryFactory */

--- a/model/tasks/CompileDelivery.php
+++ b/model/tasks/CompileDelivery.php
@@ -62,15 +62,15 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable, TaskA
         \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf');
 
         if (isset($params['deliveryClass'])) {
-            $deliveryClass = new \core_kernel_classes_Class($params['deliveryClass']);
+            $deliveryClass = $this->getClass($params['deliveryClass']);
             if (!$deliveryClass->exists()) {
-                $deliveryClass = new \core_kernel_classes_Class(DeliveryAssemblyService::CLASS_URI);
+                $deliveryClass = $this->getClass(DeliveryAssemblyService::CLASS_URI);
             }
         } else {
-            $deliveryClass = new \core_kernel_classes_Class(DeliveryAssemblyService::CLASS_URI);
+            $deliveryClass = $this->getClass(DeliveryAssemblyService::CLASS_URI);
         }
 
-        $test = new \core_kernel_classes_Resource($params['test']);
+        $test = $this->getResource($params['test']);
         $label = 'Delivery of ' . $test->getLabel();
 
         $deliveryResource =  \core_kernel_classes_ResourceFactory::create($deliveryClass);
@@ -152,11 +152,11 @@ class CompileDelivery extends AbstractAction implements \JsonSerializable, TaskA
 
     private function emulateSessionAndActionForAsynchronousCompilation(TaskInterface $task)
     {
-        $userResource = new \core_kernel_classes_Resource($task->getMetadata(TaskInterface::JSON_METADATA_OWNER_KEY));
+        $userResource = $this->getResource($task->getMetadata(TaskInterface::JSON_METADATA_OWNER_KEY));
         \common_session_SessionManager::startSession(new PretenderSession(new \core_kernel_users_GenerisUser($userResource)));
 
         /** @var LoggerService $loggerService */
-        $loggerService = $this->getServiceManager()->get(LoggerService::SERVICE_ID);
+        $loggerService = $this->getServiceLocator()->get(LoggerService::SERVICE_ID);
         $loggerService->setAction('/taoDeliveryRdf/RestDelivery/generate');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.0.0');
         }
         
-        $this->skip('7.0.0', '7.4.2');
+        $this->skip('7.0.0', '7.4.3');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.0.0');
         }
         
-        $this->skip('7.0.0', '7.4.1');
+        $this->skip('7.0.0', '7.4.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.0.0');
         }
 
-        $this->skip('7.0.0', '7.4.2');
+        $this->skip('7.0.0', '7.4.3');
     }
 }


### PR DESCRIPTION
When the delivery compilation is done from CLI it does not properly populate the user information on the "Delivery Created Event" that is created. This fix creates a temporary session for the current compilation task and sets the proper action for the event log.