### PR TITLE
TAO-6785 - Escape label html

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '7.4.3',
+  'version'     => '7.4.4',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -247,6 +247,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.0.0');
         }
 
-        $this->skip('7.0.0', '7.4.3');
+        $this->skip('7.0.0', '7.4.4');
     }
 }

--- a/views/templates/Publish/index.tpl
+++ b/views/templates/Publish/index.tpl
@@ -2,7 +2,7 @@
 use oat\tao\helpers\Template;
 ?>
 <link rel="stylesheet" type="text/css" href="<?= Template::css('selector.css')?>"/>
-<div class="selector-container" data-root-class="<?=get_data('rootClassUri')?>" data-test="<?=get_data('testUri')?>" data-label="<?=get_data('label')?>">
+<div class="selector-container" data-root-class="<?=get_data('rootClassUri')?>" data-test="<?=get_data('testUri')?>" data-label="<?=_dh(get_data('label'))?>">
 </div>
 <?php
 Template::inc('footer.tpl', 'tao');


### PR DESCRIPTION
Possible vulnerability:
We are getting label text with getdata which by default does not escape html or more specifically script tags coming from test labels.