### PR TITLE
TAO-8697 - Replace Calls of singleton method by ServiceManager calls

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '8.3.2',
+  'version'     => '8.3.3',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -258,6 +258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.6.0');
         }
 
-        $this->skip('7.6.0', '8.3.2');
+        $this->skip('7.6.0', '8.3.3');
     }
 }

--- a/test/integration/controller/RestDeliveryTest.php
+++ b/test/integration/controller/RestDeliveryTest.php
@@ -30,7 +30,7 @@ class RestDeliveryTest extends RestTestRunner
             $this->markTestSkipped('taoQtiTest extension is not available.');
         }
 
-        $this->deliveryService = DeliveryAssemblyService::singleton();
+        $this->deliveryService = new DeliveryAssemblyService();
         $this->testService     = \taoQtiTest_models_classes_QtiTestService::singleton();
         $this->itemService     = \taoItems_models_classes_ItemsService::singleton();
     }

--- a/test/integration/model/GroupAssignmentTest.php
+++ b/test/integration/model/GroupAssignmentTest.php
@@ -43,7 +43,6 @@ class DeliveryServerServiceTest extends TaoPhpUnitTestRunner
      */
     public function __construct($name = null, array $data = array(), $dataName = '') {
         parent::__construct($name, $data, $dataName);
-        common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf');
     }
 
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8697
Replace Calls of singleton method by ServiceManager calls

Classes which are extending the OntologyClass ConfigurableService, are retrieved by using the ServiceManager::get() method instead of calling the deprecated singleton method.