### PR TITLE
Feature/tao 8853/extract source file reading

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '8.3.0',
+  'version'     => '8.3.0.1',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/model/export/AssemblyExportFailedException.php
+++ b/model/export/AssemblyExportFailedException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoDeliveryRdf\model\export;
+
+use common_exception_ClientException;
+
+class AssemblyExportFailedException extends common_exception_ClientException
+{
+    /**
+     * @return string
+     */
+    public function getUserMessage()
+    {
+        return $this->getMessage();
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -258,6 +258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.6.0');
         }
 
-        $this->skip('7.6.0', '8.3.0');
+        $this->skip('7.6.0', '8.3.0.1');
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-8853

The goal of this PR is to refactor AssemblerService to make it possible to encrypt delivery files during export using another service.

How to test: run `php index.php 'oat\taoDeliveryRdf\model\export\ExportAssembly' {DELIVERY_URI} {DESTINATION_FILE.zip}` in base branch and in new branch and compare that exported assembly is the same in both cases.