### PR TITLE
Backport/tao 8853/import assembly with original delivery uri

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '8.3.4',
+  'version'     => '8.4.0',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/model/AssemblerServiceInterface.php
+++ b/model/AssemblerServiceInterface.php
@@ -40,9 +40,10 @@ interface AssemblerServiceInterface
      *
      * @param \core_kernel_classes_Class $deliveryClass
      * @param string $archiveFile Path to archive file.
+     * @param boolean $useOriginalUri Use original delivery URI from assembly package
      * @return \common_report_Report
      */
-    public function importDelivery(\core_kernel_classes_Class $deliveryClass, $archiveFile);
+    public function importDelivery(\core_kernel_classes_Class $deliveryClass, $archiveFile, $useOriginalUri = false);
 
     /**
      * Export Compiled Delivery

--- a/model/import/AssemblerService.php
+++ b/model/import/AssemblerService.php
@@ -19,6 +19,8 @@
  */
 namespace oat\taoDeliveryRdf\model\import;
 
+use common_Utils;
+use oat\generis\model\OntologyAwareTrait;
 use ZipArchive;
 use common_report_Report;
 use core_kernel_classes_Resource;
@@ -47,6 +49,7 @@ use oat\generis\model\OntologyRdf;
 class AssemblerService extends ConfigurableService implements AssemblerServiceInterface
 {
     use LoggerAwareTrait;
+    use OntologyAwareTrait;
 
     const MANIFEST_FILE = 'manifest.json';
     
@@ -64,9 +67,11 @@ class AssemblerService extends ConfigurableService implements AssemblerServiceIn
     /**
      * @param core_kernel_classes_Class $deliveryClass
      * @param string $archiveFile
+     * @param boolean $useOriginalUri Use original delivery URI from assembly package
+     *
      * @return common_report_Report
      */
-    public function importDelivery(core_kernel_classes_Class $deliveryClass, $archiveFile)
+    public function importDelivery(core_kernel_classes_Class $deliveryClass, $archiveFile, $useOriginalUri = false)
     {
         try {
             $this->importFolder = \tao_helpers_File::createTempDir();
@@ -78,7 +83,10 @@ class AssemblerService extends ConfigurableService implements AssemblerServiceIn
             $zip->close();
 
             $this->importDeliveryFiles($this->importFolder);
-            $delivery = $this->importDeliveryResource($deliveryClass);
+
+            $deliveryUri = $this->getDeliveryUri($useOriginalUri);
+            $delivery = $this->importDeliveryResource($deliveryClass, $deliveryUri);
+
             $report = common_report_Report::createSuccess(__('Delivery "%s" successfully imported',$delivery->getUri()), $delivery);
 
             return $report;
@@ -130,49 +138,96 @@ class AssemblerService extends ConfigurableService implements AssemblerServiceIn
      * @param $folder
      * @return array
      */
-    protected function getAdditionalProperties($folder)
+    protected function getAdditionalProperties(FileIterator $rdfIterator)
     {
-        $rdfPath = $folder.self::RDF_FILE;
-        
-        $properties = array();
-        if (file_exists($rdfPath)) {
-            $blacklist = array(OntologyRdf::RDF_TYPE);
-            $rdfIterator = new FileIterator($rdfPath, 1);
-            foreach ($rdfIterator as $triple) {
-                if (!in_array($triple->predicate, $blacklist)) {
-                    if (!isset($properties[$triple->predicate])) {
-                        $properties[$triple->predicate] = array();
-                    }
-                    $properties[$triple->predicate][] = $triple->object;
+        $properties = [];
+        $blacklist = array(OntologyRdf::RDF_TYPE);
+        foreach ($rdfIterator as $triple) {
+            if (!in_array($triple->predicate, $blacklist)) {
+                if (!isset($properties[$triple->predicate])) {
+                    $properties[$triple->predicate] = array();
                 }
+                $properties[$triple->predicate][] = $triple->object;
             }
         }
+
         return $properties;
     }
 
     /**
-     * @param core_kernel_classes_Class $deliveryClass
-     * @return core_kernel_classes_Resource
+     * @param $folder
+     * @return FileIterator
+     *
+     * @throws AssemblyImportFailedException
      */
-    protected function importDeliveryResource(core_kernel_classes_Class $deliveryClass)
+    protected function getRdfResourceIterator($folder)
+    {
+        $rdfPath = $folder.self::RDF_FILE;
+        if (!file_exists($rdfPath)) {
+            throw new AssemblyImportFailedException("Delivery rdf file {$rdfPath} does not exist");
+        }
+
+        return new FileIterator($rdfPath, 1);
+    }
+
+    /**
+     * @param core_kernel_classes_Class $deliveryClass
+     * @param $deliveryUri
+     *
+     * @return core_kernel_classes_Resource
+     * @throws AssemblyImportFailedException
+     */
+    protected function importDeliveryResource(core_kernel_classes_Class $deliveryClass, $deliveryUri)
     {
         $manifest       = $this->getDeliveryManifest();
         $label          = $manifest['label'];
         $dirs           = $manifest['dir'];
         $serviceCall    = \tao_models_classes_service_ServiceCall::fromString(base64_decode($manifest['runtime']));
-        $resultServer   = \taoResultServer_models_classes_ResultServerAuthoringService::singleton()->getDefaultResultServer();
 
-        $properties = $this->getAdditionalProperties($this->importFolder);
+        $properties = $this->getAdditionalProperties($this->getRdfResourceIterator($this->importFolder));
         $properties = array_merge($properties, array(
             OntologyRdfs::RDFS_LABEL                          => $label,
             DeliveryAssemblyService::PROPERTY_DELIVERY_DIRECTORY => array_keys($dirs),
             DeliveryAssemblyService::PROPERTY_DELIVERY_TIME      => time(),
             DeliveryAssemblyService::PROPERTY_DELIVERY_RUNTIME   => $serviceCall->toOntology(),
-            DeliveryContainerService::PROPERTY_RESULT_SERVER      => $resultServer
         ));
-        $delivery = $deliveryClass->createInstanceWithProperties($properties);
+
+        $delivery = $this->getResource($deliveryUri);
+        if ($delivery->exists()) {
+            throw new AssemblyImportFailedException("Delivery with this URI already exist: {$deliveryUri}");
+        }
+
+        $delivery->setType($deliveryClass);
+        $delivery->setPropertiesValues($properties);
 
         return $delivery;
+    }
+
+    /**
+     * @param $useOriginalUri
+     * @return string
+     *
+     * @throws AssemblyImportFailedException
+     */
+    private function getDeliveryUri($useOriginalUri)
+    {
+        if ($useOriginalUri === false) {
+            return common_Utils::getNewUri();
+        }
+
+        $deliveryUri = null;
+        foreach ($this->getRdfResourceIterator($this->importFolder) as $triple) {
+            if ($triple->predicate == OntologyRdf::RDF_TYPE && $triple->object == DeliveryAssemblyService::CLASS_URI) {
+                $deliveryUri = $triple->subject;
+                break;
+            }
+        }
+
+        if ($deliveryUri === null) {
+            throw new AssemblyImportFailedException('Cannot find original delivery uri in delivery rdf file.');
+        }
+
+        return $deliveryUri;
     }
 
     /**

--- a/model/import/AssemblyImportFailedException.php
+++ b/model/import/AssemblyImportFailedException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoDeliveryRdf\model\import;
+
+
+class AssemblyImportFailedException extends \common_exception_ClientException
+{
+    public function getUserMessage()
+    {
+        return $this->getMessage();
+    }
+}

--- a/model/import/AssemblyImportFailedException.php
+++ b/model/import/AssemblyImportFailedException.php
@@ -19,11 +19,8 @@
 
 namespace oat\taoDeliveryRdf\model\import;
 
+use common_Exception;
 
-class AssemblyImportFailedException extends \common_exception_ClientException
+class AssemblyImportFailedException extends common_Exception
 {
-    public function getUserMessage()
-    {
-        return $this->getMessage();
-    }
 }

--- a/scripts/tools/ImportDeliveryAssembly.php
+++ b/scripts/tools/ImportDeliveryAssembly.php
@@ -87,8 +87,9 @@ class ImportDeliveryAssembly extends ScriptAction
             $importClass = $this->getImportClass();
             /** @var AssemblerServiceInterface $importer */
             $importer = $this->getServiceLocator()->get(AssemblerServiceInterface::SERVICE_ID);
+            $useOriginalUri = $this->hasOption(self::OPTION_USE_ORIGINAL_URI);
 
-            $importReport = $importer->importDelivery($importClass, $file, $this->getOption(self::OPTION_USE_ORIGINAL_URI));
+            $importReport = $importer->importDelivery($importClass, $file, $useOriginalUri);
 
             $this->report->add($importReport);
         } catch (\Exception $e) {

--- a/scripts/tools/ImportDeliveryAssembly.php
+++ b/scripts/tools/ImportDeliveryAssembly.php
@@ -24,6 +24,7 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\taoDeliveryRdf\model\AssemblerServiceInterface;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\import\AssemblyImportFailedException;
 
 class ImportDeliveryAssembly extends ScriptAction
 {
@@ -116,10 +117,13 @@ class ImportDeliveryAssembly extends ScriptAction
      */
     private function getImportClass()
     {
-        if ($this->hasOption(self::OPTION_CLASS_URI)) {
-            return $this->getOption(self::OPTION_CLASS_URI);
+        $classUri = $this->hasOption(self::OPTION_CLASS_URI) ? $this->getOption(self::OPTION_CLASS_URI) : DeliveryAssemblyService::CLASS_URI;
+        $importClass = $this->getClass($classUri);
+
+        if (!$importClass->exists()) {
+            throw new AssemblyImportFailedException("Class with provided URI does not exist: {$importClass}");
         }
 
-        return $this->getClass(DeliveryAssemblyService::CLASS_URI);
+        return $importClass;
     }
 }

--- a/scripts/tools/ImportDeliveryAssembly.php
+++ b/scripts/tools/ImportDeliveryAssembly.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoDeliveryRdf\scripts\tools;
+
+use common_report_Report as Report;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoDeliveryRdf\model\AssemblerServiceInterface;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+
+class ImportDeliveryAssembly extends ScriptAction
+{
+    use OntologyAwareTrait;
+
+    const OPTION_ASSEMBLY_FILE = 'assembly-file';
+
+    const OPTION_CLASS_URI = 'class-uri';
+
+    const OPTION_USE_ORIGINAL_URI = 'use-original-uri';
+
+    /**
+     * @var Report
+     */
+    private $report;
+
+    /**
+     * @return string
+     */
+    protected function provideDescription()
+    {
+        return 'Import compiled delivery assembly with possibility to specify class and use delivery\'s original URI';
+    }
+
+    /**
+     * @return array
+     */
+    protected function provideOptions()
+    {
+        return [
+            self::OPTION_ASSEMBLY_FILE => [
+                'prefix' => 'f',
+                'required' => true,
+                'longPrefix' => self::OPTION_ASSEMBLY_FILE,
+                'description' => 'Path to the compiled assembly file.'
+            ],
+            self::OPTION_USE_ORIGINAL_URI => [
+                'prefix' => 'uri',
+                'required' => true,
+                'flag' => true,
+                'longPrefix' => self::OPTION_USE_ORIGINAL_URI,
+                'description' => 'Use delivery URI from assembly package.',
+            ],
+            self::OPTION_CLASS_URI => [
+                'prefix' => 'class',
+                'longPrefix' => self::OPTION_CLASS_URI,
+                'description' => 'Import into provided class.',
+            ],
+        ];
+    }
+
+    /**
+     * @return Report
+     */
+    protected function run()
+    {
+        $this->report = Report::createInfo('Delivery assembly import started');
+
+        try {
+            $file = $this->getOption(self::OPTION_ASSEMBLY_FILE);
+            $importClass = $this->getImportClass();
+            /** @var AssemblerServiceInterface $importer */
+            $importer = $this->getServiceLocator()->get(AssemblerServiceInterface::SERVICE_ID);
+
+            $importReport = $importer->importDelivery($importClass, $file, $this->getOption(self::OPTION_USE_ORIGINAL_URI));
+
+            $this->report->add($importReport);
+        } catch (\Exception $e) {
+            $this->report->add(Report::createFailure("Export failed: " . $e->getMessage()));
+        }
+
+        return $this->report;
+    }
+
+    /**
+     * @return array
+     */
+    protected function provideUsage()
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Prints a help statement'
+        ];
+    }
+
+    /**
+     * @return \core_kernel_classes_Class
+     */
+    private function getImportClass()
+    {
+        if ($this->hasOption(self::OPTION_CLASS_URI)) {
+            return $this->getOption(self::OPTION_CLASS_URI);
+        }
+
+        return $this->getClass(DeliveryAssemblyService::CLASS_URI);
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -258,6 +258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.6.0');
         }
 
-        $this->skip('7.6.0', '8.3.4');
+        $this->skip('7.6.0', '8.4.0');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-8853

Backport for feature implemented in https://github.com/oat-sa/extension-tao-delivery-rdf/pull/278

The goal of this PR is to create a command which will allow to specify folder/class for import and import delivery with original delivery URI from assembly package.

How to test:
Run command php index.php 'oat\taoDeliveryRdf\scripts\tools\ImportDeliveryAssembly' -f {PATH_TO_ASSEMBLY_FILE} -uri 1