### PR TITLE
Feature/tao 8853/store results with original items identifiers

### DIFF
--- a/helper/DetectTestAndItemIdentifiersHelper.php
+++ b/helper/DetectTestAndItemIdentifiersHelper.php
@@ -41,16 +41,16 @@ class DetectTestAndItemIdentifiersHelper
         $testIdentifier = null;
         if (isset($test)) {
             $delivery = $this->getResource($deliveryId);
-            $test = $this->getResource($delivery->getOnePropertyValue($this->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN)));
-            $qtiTestIdentifier = (string) $test->getOnePropertyValue($this->getProperty(QtiTestService::PROPERTY_QTI_TEST_IDENTIFIER));
-            $testIdentifier = $qtiTestIdentifier ? implode('#', [$remoteNamespace[0], $qtiTestIdentifier]) : null;
+            $testResource = $this->getResource($delivery->getOnePropertyValue($this->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN)));
+            $qtiTestIdentifier = (string) $testResource->getOnePropertyValue($this->getProperty(QtiTestService::PROPERTY_QTI_TEST_IDENTIFIER));
+            $testIdentifier = $qtiTestIdentifier ? implode('#', [$remoteNamespace[0], $qtiTestIdentifier]) : $test;
         }
 
         $itemIdentifier = null;
         if (isset($item)) {
-            $item = $this->getResource($item);
-            $qtiItemIdentifier = (string) $item->getOnePropertyValue($this->getProperty(ImportService::PROPERTY_QTI_ITEM_IDENTIFIER));
-            $itemIdentifier = $qtiItemIdentifier ? implode('#', [$remoteNamespace[0], $qtiItemIdentifier]) : null;
+            $itemResource = $this->getResource($item);
+            $qtiItemIdentifier = (string) $itemResource->getOnePropertyValue($this->getProperty(ImportService::PROPERTY_QTI_ITEM_IDENTIFIER));
+            $itemIdentifier = $qtiItemIdentifier ? implode('#', [$remoteNamespace[0], $qtiItemIdentifier]) : $item;
         }
 
         return [$testIdentifier, $itemIdentifier];

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '8.3.0.1',
+  'version'     => '8.3.0.3',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
 	    'generis'     => '>=6.14.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -258,6 +258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.6.0');
         }
 
-        $this->skip('7.6.0', '8.3.0.1');
+        $this->skip('7.6.0', '8.3.0.3');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-8853

The goal of this development is to use original test and item identifiers in result variables if delivery was imported from assembly package and appropriate item and test resources do not exist