### PR TITLE
Prevent publishing of empty tests

### DIFF
--- a/controller/Publish.php
+++ b/controller/Publish.php
@@ -58,12 +58,21 @@ class Publish extends \tao_actions_SaSModule
             $testUri = $this->getRequestParameter('testUri');
             $classUri = $this->getRequestParameter('classUri');
             $test = $this->getResource($testUri);
+
+            $testService = \taoTests_models_classes_TestsService::singleton();
+            $testItems = $testService->getTestItems($test);
+            if (empty($testItems)) {
+                throw new \RuntimeException(
+                    __('The test "%s" does not contain any items and cannot be published.', $test->getLabel())
+                );
+            }
+
             $deliveryClass = $this->getClass($classUri);
             /** @var DeliveryFactory $deliveryFactoryResources */
             $deliveryFactoryResources = $this->getServiceManager()->get(DeliveryFactory::SERVICE_ID);
             $initialProperties = $deliveryFactoryResources->getInitialPropertiesFromArray([OntologyRdfs::RDFS_LABEL => 'new delivery']);
             return $this->returnTaskJson(CompileDelivery::createTask($test, $deliveryClass, $initialProperties));
-        }catch(\Exception $e){
+        } catch(\Exception $e) {
             return $this->returnJson([
                 'success' => false,
                 'errorMsg' => $e instanceof \common_exception_UserReadableException ? $e->getUserMessage() : $e->getMessage(),

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '9.0.0',
+  'version'     => '9.0.1',
 	'author'      => 'Open Assessment Technologies SA',
 	'requires'    => array(
         'generis'     => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -258,6 +258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.6.0');
         }
 
-        $this->skip('7.6.0', '9.0.0');
+        $this->skip('7.6.0', '9.0.1');
     }
 }

--- a/views/js/controller/Publish/index.js
+++ b/views/js/controller/Publish/index.js
@@ -95,6 +95,9 @@ define([
                 refreshTree(testUri);
             })
             .on('error', function(err){
+                if (err && err.errorMsg) {
+                    err = err.errorMsg;
+                }
                 feedback().error(err);
             });
         }


### PR DESCRIPTION
Added the same check that is implemented on the test search on the deliveries page.