### PR TITLE
Feature/actp 282/enable plugins from activated features

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '10.2.2',
+  'version'     => '11.0.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.5.0',

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -181,12 +181,12 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
         try {
             $testRunnerFeatureService = $this->getServiceLocator()->get(TestRunnerFeatureService::SERVICE_ID);
             $allTestRunnerFeatures = $testRunnerFeatureService->getAll();
-            $activeTestRunnerFeaturesIds = $this->getActiveFeatures($delivery);
 
             if (count($allTestRunnerFeatures) === 0) {
                 return $disabledPlugins;
             }
 
+            $activeTestRunnerFeaturesIds = $this->getActiveFeatures($delivery);
             foreach ($allTestRunnerFeatures as $feature) {
                 if (in_array($feature->getId(), $activeTestRunnerFeaturesIds)) {
                     $enabledPlugins = array_merge($enabledPlugins, $feature->getPluginsIds());

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -178,8 +178,7 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
     {
         $disabledDeliveryPlugins = [];
         try {
-            $testRunnerFeatureService = $this->getServiceLocator()->get(TestRunnerFeatureService::SERVICE_ID);
-            $allTestRunnerFeatures = $testRunnerFeatureService->getAll();
+            $allTestRunnerFeatures = $this->getAllAvailableFeatures();
 
             if (empty($allTestRunnerFeatures)) {
                 return $disabledDeliveryPlugins;
@@ -209,5 +208,16 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
         }
 
         return $disabledDeliveryPlugins;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getAllAvailableFeatures()
+    {
+        $testRunnerFeatureService = $this->getServiceLocator()->get(TestRunnerFeatureService::SERVICE_ID);
+        $allTestRunnerFeatures = $testRunnerFeatureService->getAll();
+
+        return $allTestRunnerFeatures;
     }
 }

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -176,30 +176,31 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
      */
     protected function getPluginsDisabledForDelivery(core_kernel_classes_Resource $delivery)
     {
-        $enabledPlugins = [[]];
-        $disabledPlugins = [[]];
+        $disabledDeliveryPlugins = [];
         try {
             $testRunnerFeatureService = $this->getServiceLocator()->get(TestRunnerFeatureService::SERVICE_ID);
             $allTestRunnerFeatures = $testRunnerFeatureService->getAll();
 
             if (empty($allTestRunnerFeatures)) {
-                return $disabledPlugins;
+                return $disabledDeliveryPlugins;
             }
 
+            $enabledFeaturesPlugins = [[]];
+            $disabledFeaturesPlugins = [[]];
             $activeTestRunnerFeaturesIds = $this->getActiveFeatures($delivery);
             foreach ($allTestRunnerFeatures as $feature) {
                 if (in_array($feature->getId(), $activeTestRunnerFeaturesIds, true)) {
-                    $enabledPlugins[] = $feature->getPluginsIds();
+                    $enabledFeaturesPlugins[] = $feature->getPluginsIds();
                 } else {
-                    $disabledPlugins[] = $feature->getPluginsIds();
+                    $disabledFeaturesPlugins[] = $feature->getPluginsIds();
                 }
             }
 
-            $enabledPlugins = array_unique(array_merge(...$enabledPlugins));
-            $disabledPlugins = array_unique(array_merge(...$disabledPlugins));
+            $enabledPlugins = array_unique(array_merge(...$enabledFeaturesPlugins));
+            $disabledPlugins = array_unique(array_merge(...$disabledFeaturesPlugins));
 
             // We disable only plugins which are not enabled via any other active test runner feature.
-            $disabledPlugins = array_diff($disabledPlugins, $enabledPlugins);
+            $disabledDeliveryPlugins = array_diff($disabledPlugins, $enabledPlugins);
         } catch (common_exception_Error $e) {
             $this->logWarning(
                 'Error getting plugins disabled for delivery.',
@@ -207,6 +208,6 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
             );
         }
 
-        return $disabledPlugins;
+        return $disabledDeliveryPlugins;
     }
 }

--- a/model/DeliveryContainerService.php
+++ b/model/DeliveryContainerService.php
@@ -100,7 +100,7 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
         $allPlugins = $pluginService->getAllPlugins();
 
         $pluginsToDisable = $this->getPluginsDisabledForDelivery($deliveryExecution->getDelivery());
-        if (count($pluginsToDisable) > 0) {
+        if (!empty($pluginsToDisable)) {
             foreach ($allPlugins as $plugin) {
                 if (!is_null($plugin) && in_array($plugin->getId(), $pluginsToDisable)) {
                     $plugin->setActive(false);
@@ -176,27 +176,27 @@ class DeliveryContainerService extends ConfigurableService implements DeliveryCo
      */
     protected function getPluginsDisabledForDelivery(core_kernel_classes_Resource $delivery)
     {
-        $enabledPlugins = [];
-        $disabledPlugins = [];
+        $enabledPlugins = [[]];
+        $disabledPlugins = [[]];
         try {
             $testRunnerFeatureService = $this->getServiceLocator()->get(TestRunnerFeatureService::SERVICE_ID);
             $allTestRunnerFeatures = $testRunnerFeatureService->getAll();
 
-            if (count($allTestRunnerFeatures) === 0) {
+            if (empty($allTestRunnerFeatures)) {
                 return $disabledPlugins;
             }
 
             $activeTestRunnerFeaturesIds = $this->getActiveFeatures($delivery);
             foreach ($allTestRunnerFeatures as $feature) {
-                if (in_array($feature->getId(), $activeTestRunnerFeaturesIds)) {
-                    $enabledPlugins = array_merge($enabledPlugins, $feature->getPluginsIds());
+                if (in_array($feature->getId(), $activeTestRunnerFeaturesIds, true)) {
+                    $enabledPlugins[] = $feature->getPluginsIds();
                 } else {
-                    $disabledPlugins = array_merge($disabledPlugins, $feature->getPluginsIds());
+                    $disabledPlugins[] = $feature->getPluginsIds();
                 }
             }
 
-            $enabledPlugins = array_unique($enabledPlugins);
-            $disabledPlugins = array_unique($disabledPlugins);
+            $enabledPlugins = array_unique(array_merge(...$enabledPlugins));
+            $disabledPlugins = array_unique(array_merge(...$disabledPlugins));
 
             // We disable only plugins which are not enabled via any other active test runner feature.
             $disabledPlugins = array_diff($disabledPlugins, $enabledPlugins);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -263,6 +263,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.0.0');
         }
 
-        $this->skip('10.0.0', '10.2.2');
+        $this->skip('10.0.0', '11.0.0');
     }
 }

--- a/test/unit/model/DeliveryContainerServiceTest.php
+++ b/test/unit/model/DeliveryContainerServiceTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020  (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoDeliveryRdf\test\unit\model;
+
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDeliveryRdf\model\DeliveryContainerService;
+use oat\taoTests\models\runner\features\TestRunnerFeatureInterface;
+use oat\taoTests\models\runner\features\TestRunnerFeatureService;
+use oat\taoTests\models\runner\plugins\TestPlugin;
+use oat\taoTests\models\runner\plugins\TestPluginService;
+
+class DeliveryContainerServiceTest extends TestCase
+{
+    /**
+     * @var DeliveryContainerService
+     */
+    public $object;
+
+    /**
+     * @var TestPluginService|MockObject
+     */
+    public $testPluginServiceMock;
+
+    /**
+     * @var LoggerService|MockObject
+     */
+    public $loggerMock;
+
+    /**
+     * @var TestRunnerFeatureService|MockObject
+     */
+    public $testRunnerFeatureServiceMock;
+
+    /**
+     * @var Ontology|MockObject
+     */
+    public $ontologyModelMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->testPluginServiceMock = $this->createMock(TestPluginService::class);
+        $this->testRunnerFeatureServiceMock = $this->createMock(TestRunnerFeatureService::class);
+        $this->loggerMock = $this->createMock(LoggerService::class);
+
+        $ontologyModelMock = $this->createMock(Ontology::class);
+        $ontologyModelMock->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $slMock = $this->getServiceLocatorMock(
+            [
+                TestPluginService::SERVICE_ID => $this->testPluginServiceMock,
+                TestRunnerFeatureService::SERVICE_ID => $this->testRunnerFeatureServiceMock,
+                LoggerService::SERVICE_ID => $this->loggerMock
+            ]
+        );
+
+        $this->object = new DeliveryContainerService();
+        $this->object->setServiceLocator($slMock);
+        $this->object->setModel($ontologyModelMock);
+    }
+
+    public function testGetPluginsNoActivePlugins()
+    {
+        $expectedResult = [];
+        $this->testPluginServiceMock->method('getAllPlugins')
+            ->willReturn([]);
+
+        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
+        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
+        $deliveryExecutionMock->method('getDelivery')
+            ->willReturn($deliveryMock);
+
+        $this->testRunnerFeatureServiceMock->method('getAll')
+            ->willReturn([]);
+
+        $result = $this->object->getPlugins($deliveryExecutionMock);
+
+        $this->assertTrue(is_array($result), 'Method must return an array.');
+        $this->assertEquals($expectedResult, $result, 'Returned list of plugins must be as expected.');
+    }
+
+    public function testGetPluginsNoConfiguredFeatures()
+    {
+        $allPlugins = $this->getPluginsMocks(['plugin1' => true, 'plugin2' => false, 'plugin3' => true]);
+        $expectedResult = $this->getPluginsMocks(['plugin1' => true, 'plugin3' => true]);
+
+        $this->testPluginServiceMock->method('getAllPlugins')
+            ->willReturn($allPlugins);
+
+        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
+        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
+        $deliveryExecutionMock->method('getDelivery')
+            ->willReturn($deliveryMock);
+
+        $this->testRunnerFeatureServiceMock->method('getAll')
+            ->willReturn([]);
+
+        $result = $this->object->getPlugins($deliveryExecutionMock);
+
+        $this->assertTrue(is_array($result), 'Method must return an array.');
+        $this->assertEquals($expectedResult, $result, 'Method must return only active plugins.');
+    }
+
+    /**
+     * @param string $deliveryFeatures
+     * @param array $expectedEnabledPlugins
+     *
+     * @dataProvider dataProviderTestGetPluginsDeliveryWithFeatures
+     */
+    public function testGetPluginsDeliveryWithFeatures($deliveryFeatures, array $expectedEnabledPlugins)
+    {
+        $allPlugins = $this->getPluginsMocks(['plugin1' => true, 'plugin2' => false, 'plugin3' => true, 'plugin4' => true]);
+        $expectedEnabledPlugins = $this->getPluginsMocks($expectedEnabledPlugins);
+
+        $this->testPluginServiceMock->method('getAllPlugins')
+            ->willReturn($allPlugins);
+
+        // Mock features activated for delivery
+        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
+        $deliveryMock->method('getOnePropertyValue')
+            ->willReturn($deliveryFeatures);
+        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
+        $deliveryExecutionMock->method('getDelivery')
+            ->willReturn($deliveryMock);
+
+        // Mock all features
+        $featureMock1 = $this->createMock(TestRunnerFeatureInterface::class);
+        $featureMock1->method('getId')->willReturn('feature1');
+        $featureMock1->method('getPluginsIds')->willReturn(['plugin1', 'plugin2', 'plugin4']);
+
+        $featureMock2 = $this->createMock(TestRunnerFeatureInterface::class);
+        $featureMock2->method('getId')->willReturn('feature2');
+        $featureMock2->method('getPluginsIds')->willReturn(['plugin2', 'plugin3', 'plugin4']);
+
+        $this->testRunnerFeatureServiceMock->method('getAll')
+            ->willReturn([$featureMock1, $featureMock2]);
+
+        $result = $this->object->getPlugins($deliveryExecutionMock);
+
+        $this->assertTrue(is_array($result), 'Method must return an array.');
+        $this->assertEquals($expectedEnabledPlugins, $result, 'Method must return only active plugins.');
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderTestGetPluginsDeliveryWithFeatures()
+    {
+        return [
+            'All features enabled' => [
+                'deliveryFeatures' => 'feature1,feature2',
+                'expectedEnabledPlugins' => ['plugin1' => true, 'plugin3' => true, 'plugin4' => true],
+            ],
+            'All features disabled' => [
+                'deliveryFeatures' => '',
+                'expectedEnabledPlugins' => [],
+            ],
+            'Feature1 enabled' => [
+                'deliveryFeatures' => 'feature1',
+                'expectedEnabledPlugins' => ['plugin1' => true, 'plugin4' => true],
+            ],
+            'Feature2 enabled' => [
+                'deliveryFeatures' => 'feature2',
+                'expectedEnabledPlugins' => ['plugin3' => true, 'plugin4' => true],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $plugins Format ['pluginId' => true|false]
+     * @return array
+     */
+    protected function getPluginsMocks(array $plugins)
+    {
+        $pluginsMocks = [];
+        foreach ($plugins as $pluginId => $active) {
+            $pluginMock = $this->getMockBuilder(TestPlugin::class)
+                ->disableOriginalConstructor()
+                ->disableOriginalClone()
+                ->disableArgumentCloning()
+                ->setMethods(['getId'])
+                ->getMock();
+            $pluginMock->method('getId')
+                ->willReturn($pluginId);
+            $pluginMock->setActive($active);
+
+            $pluginsMocks[$pluginId] = $pluginMock;
+        }
+
+        return $pluginsMocks;
+    }
+}

--- a/test/unit/model/DeliveryContainerServiceTest.php
+++ b/test/unit/model/DeliveryContainerServiceTest.php
@@ -88,10 +88,8 @@ class DeliveryContainerServiceTest extends TestCase
         $this->testPluginServiceMock->method('getAllPlugins')
             ->willReturn([]);
 
-        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
-        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
-        $deliveryExecutionMock->method('getDelivery')
-            ->willReturn($deliveryMock);
+        $deliveryFeatures = '';
+        $deliveryExecutionMock = $this->getDeliveryExecutionMock($deliveryFeatures);
 
         $this->testRunnerFeatureServiceMock->method('getAll')
             ->willReturn([]);
@@ -110,10 +108,8 @@ class DeliveryContainerServiceTest extends TestCase
         $this->testPluginServiceMock->method('getAllPlugins')
             ->willReturn($allPlugins);
 
-        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
-        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
-        $deliveryExecutionMock->method('getDelivery')
-            ->willReturn($deliveryMock);
+        $deliveryFeatures = '';
+        $deliveryExecutionMock = $this->getDeliveryExecutionMock($deliveryFeatures);
 
         $this->testRunnerFeatureServiceMock->method('getAll')
             ->willReturn([]);
@@ -139,12 +135,7 @@ class DeliveryContainerServiceTest extends TestCase
             ->willReturn($allPlugins);
 
         // Mock features activated for delivery
-        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
-        $deliveryMock->method('getOnePropertyValue')
-            ->willReturn($deliveryFeatures);
-        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
-        $deliveryExecutionMock->method('getDelivery')
-            ->willReturn($deliveryMock);
+        $deliveryExecutionMock = $this->getDeliveryExecutionMock($deliveryFeatures);
 
         // Mock all features
         $featureMock1 = $this->createMock(TestRunnerFeatureInterface::class);
@@ -211,5 +202,20 @@ class DeliveryContainerServiceTest extends TestCase
         }
 
         return $pluginsMocks;
+    }
+
+    /**
+     * @param string $deliveryFeatures
+     * @return DeliveryExecution|MockObject
+     */
+    protected function getDeliveryExecutionMock($deliveryFeatures)
+    {
+        $deliveryMock = $this->createMock(core_kernel_classes_Resource::class);
+        $deliveryMock->method('getOnePropertyValue')
+            ->willReturn($deliveryFeatures);
+        $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
+        $deliveryExecutionMock->method('getDelivery')
+            ->willReturn($deliveryMock);
+        return $deliveryExecutionMock;
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-282

The goal of this PR is to modify current functionality how plugins are enabled/disabled via test runner features.
**Current behavior:** If there are more that 1 feature configured and the same plugin is present in multiple features, to activate this plugin all features were it's present must be enabled. It doesn't allow us to have multiple features with list of plugins which overlap and configure enabled plugins per delivery via features.

**New behavior:** If there are more than 1 feature and the same plugin is present in multiple features, to activate this plugin at least one feature where it's present must be activated. With this approach we may have different features with plugins required only for this feature and enable specific plugins per delivery.

**How to test:**
- register two (or more) features with list of plugins which overlap (example: feature1 - (plugin1, plugin2), feature2 - (plugin2, plugin3)) and test delivery with different combinations of enabled features(plugins).
