### PR TITLE
Feature/actp 282/cache plugins within the same process

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.0.0',
+  'version'     => '11.1.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -263,6 +263,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('10.0.0');
         }
 
-        $this->skip('10.0.0', '11.0.0');
+        $this->skip('10.0.0', '11.1.0');
     }
 }

--- a/test/unit/model/DeliveryContainerServiceTest.php
+++ b/test/unit/model/DeliveryContainerServiceTest.php
@@ -118,6 +118,13 @@ class DeliveryContainerServiceTest extends TestCase
 
         $this->assertTrue(is_array($result), 'Method must return an array.');
         $this->assertEquals($expectedResult, $result, 'Method must return only active plugins.');
+
+        // Test plugins caching - getAllPlugins method should not be called again
+        $this->testPluginServiceMock->expects($this->never())
+            ->method('getAllPlugins');
+
+        $result2 = $this->object->getPlugins($deliveryExecutionMock);
+        $this->assertEquals($expectedResult, $result2, 'On consecutive calls method must return the same plugins.');
     }
 
     /**

--- a/test/unit/model/DeliveryContainerServiceTest.php
+++ b/test/unit/model/DeliveryContainerServiceTest.php
@@ -123,8 +123,8 @@ class DeliveryContainerServiceTest extends TestCase
         $this->testPluginServiceMock->expects($this->never())
             ->method('getAllPlugins');
 
-        $result2 = $this->object->getPlugins($deliveryExecutionMock);
-        $this->assertEquals($expectedResult, $result2, 'On consecutive calls method must return the same plugins.');
+        $resultFromCache = $this->object->getPlugins($deliveryExecutionMock);
+        $this->assertEquals($expectedResult, $resultFromCache, 'On consecutive calls method must return the same plugins.');
     }
 
     /**


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-282

`DeliveryContainerService::getPlugins()` method my be called multiple times within the same request. Added caching for test runner plugins withing the same request to improve performance.