### PR TITLE
fixed error messages

### DIFF
--- a/controller/RestDelivery.php
+++ b/controller/RestDelivery.php
@@ -19,8 +19,11 @@
 
 namespace oat\taoDeliveryRdf\controller;
 
+use common_exception_RestApi;
+use core_kernel_classes_Class;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\oatbox\event\EventManager;
+use oat\search\base\exception\SearchGateWayExeption;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\tao\model\taskQueue\TaskLog\Broker\TaskLogBrokerInterface;
 use oat\tao\model\taskQueue\TaskLog\Entity\EntityInterface;
@@ -72,7 +75,7 @@ class RestDelivery extends \tao_actions_RestController
 
             $test = $this->getResource($this->getRequestParameter(self::REST_DELIVERY_TEST_ID));
             if (!$test->exists()) {
-                throw new \common_exception_NotFound('Unable to find a test associated to the given uri.');
+                throw new common_exception_RestApi('Unable to find a test associated to the given uri.');
             }
 
             $label = 'Delivery of ' . $test->getLabel();
@@ -112,7 +115,7 @@ class RestDelivery extends \tao_actions_RestController
 
             $test = $this->getResource($this->getRequestParameter(self::REST_DELIVERY_TEST_ID));
             if (! $test->exists()) {
-                throw new \common_exception_NotFound('Unable to find a test associated to the given uri.');
+                throw new common_exception_RestApi('Unable to find a test associated to the given uri.');
             }
 
             $deliveryClass = $this->getDeliveryClassByParameters();
@@ -413,7 +416,7 @@ class RestDelivery extends \tao_actions_RestController
      * If not parent class parameter is provided, class will be created under root class
      * Comment parameter is not mandatory, used to describe new created class
      *
-     * @return \core_kernel_classes_Class
+     * @return core_kernel_classes_Class
      */
     public function createClass()
     {
@@ -443,9 +446,9 @@ class RestDelivery extends \tao_actions_RestController
      * If an uri parameter is provided, and it is a delivery class, this delivery class is returned
      * If a label parameter is provided, and only one delivery class has this label, this delivery class is returned
      *
-     * @return \core_kernel_classes_Class
-     * @throws \common_Exception
-     * @throws \common_exception_NotFound
+     * @return core_kernel_classes_Class
+     * @throws SearchGateWayExeption
+     * @throws common_exception_RestApi
      */
     protected function getDeliveryClassByParameters()
     {
@@ -460,7 +463,7 @@ class RestDelivery extends \tao_actions_RestController
             ) {
                 return $deliveryClass;
             }
-            throw new \common_Exception(__('Delivery class uri provided is not a valid delivery class.'));
+            throw new common_exception_RestApi(__('Delivery class uri provided is not a valid delivery class.'));
         }
 
         if ($this->hasRequestParameter(self::REST_DELIVERY_CLASS_LABEL)) {
@@ -484,7 +487,7 @@ class RestDelivery extends \tao_actions_RestController
 
             switch ($result->count()) {
                 case 0:
-                    throw new \common_exception_NotFound(__('Delivery with label "%s" not found', $label));
+                    throw new common_exception_RestApi(__('Delivery with label "%s" not found', $label));
                 case 1:
                     return $this->getClass($result->current()->getUri());
                 default:
@@ -492,7 +495,7 @@ class RestDelivery extends \tao_actions_RestController
                     foreach ($result as $raw) {
                         $availableClasses[] = $raw->getUri();
                     }
-                    throw new \common_exception_NotFound(__(
+                    throw new common_exception_RestApi(__(
                         'Multiple delivery class found for label "%s": %s',
                         $label,
                         implode(',', $availableClasses)
@@ -506,7 +509,7 @@ class RestDelivery extends \tao_actions_RestController
     /**
      * Get the delivery root class
      *
-     * @return \core_kernel_classes_Class
+     * @return core_kernel_classes_Class
      */
     protected function getDeliveryRootClass()
     {

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.5.0',
+  'version'     => '11.5.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -269,5 +269,7 @@ class Updater extends \common_ext_ExtensionUpdater
             OntologyUpdater::syncModels();
             $this->setVersion('11.5.0');
         }
+
+        $this->skip('11.5.0', '11.5.1');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TCA-445
 
This PR makes error messages of the RestDelivery controller more clear for the end user.
 
#### How to test
 
- create 2 folders in the deliveries section of the backoffice with name `Morris+Deliveries`
- run generateDeffered action

Example:
```
POST http://tao-act.loc/taoDeliveryRdf/RestDelivery/generateDeferred?XDEBUG_SESSION_START=1&test=http://sample/act.rdf#i5e8f47813d7028902717fd081facd4cc38&delivery-label=Morris Deliveries
Accept: application/json
Cache-Control: no-cache
User-Agent: php-storm
Accept-Encoding: gzip
Connection: keep-alive
Content-Type: applicatio/x-www-form-urlencoded
Authorization: Basic c2h1cmljazpHZmhmeWp6ITEyMzQ=
```

Expected answer:

```
POST http://tao-act.loc/taoDeliveryRdf/RestDelivery/generateDeferred?XDEBUG_SESSION_START=1&test=http%3A%2F%2Fsample%2Fact.rdf%23i5e8f47813d7028902717fd081facd4cc38&delivery-label=Morris+Deliveries

HTTP/1.1 400 Bad Request
Server: nginx/1.17.9
Date: Wed, 15 Apr 2020 10:37:20 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
X-Powered-By: PHP/7.4.3
Set-Cookie: XDEBUG_SESSION=1; expires=Wed, 15-Apr-2020 11:37:19 GMT; Max-Age=3600; path=/
X-Content-Type-Options: nosniff
Content-Security-Policy: frame-ancestors 'self'
Strict-Transport-Security: max-age=0; includeSubDomains;

{
  "success": false,
  "errorCode": 0,
  "errorMsg": "Multiple delivery class found for label \"Morris Deliveries\": http:\/\/sample\/act.rdf#i5e9594de5a1a7890274509fabbe756483e,http:\/\/sample\/act.rdf#i5e96d76e6db3e49382a04c7ef653de2c63",
  "version": "3.4.0-sprint126"
}

Response code: 400 (Bad Request); Time: 233ms; Content length: 257 bytes
```