### PR TITLE
Fix/delivery delete

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.5.1',
+  'version'     => '11.5.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/model/Delete/DeliveryDeleteAction.php
+++ b/model/Delete/DeliveryDeleteAction.php
@@ -46,12 +46,4 @@ class DeliveryDeleteAction extends AbstractAction
         $task = $this->propagate(new DeliveryDeleteTask());
         return $task(['deliveryId' => $params[0]]);
     }
-
-    /**
-     * @return mixed|string
-     */
-    public function jsonSerialize()
-    {
-        return __CLASS__;
-    }
 }

--- a/model/Delete/DeliveryDeleteAction.php
+++ b/model/Delete/DeliveryDeleteAction.php
@@ -15,14 +15,15 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  *
  */
+
+declare(strict_types = 1);
 
 namespace oat\taoDeliveryRdf\model\Delete;
 
 use oat\oatbox\extension\AbstractAction;
-use oat\tao\model\taskQueue\QueueDispatcher;
 
 /**
  * Usage example:

--- a/model/Delete/DeliveryDeleteAction.php
+++ b/model/Delete/DeliveryDeleteAction.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoDeliveryRdf\model\Delete;
+
+use oat\oatbox\extension\AbstractAction;
+use oat\tao\model\taskQueue\QueueDispatcher;
+
+/**
+ * Usage example:
+ * sudo -u www-data php index.php '\oat\taoDeliveryRdf\model\Delete\DeliveryDeleteAction' 'http://tao.local/tao.rdf#i5ec66a0a167263604f8a6c91908fa8ab3'
+ * Class DeliveryDeleteAction
+ * @package oat\taoDeliveryRdf\model\Delete
+ */
+class DeliveryDeleteAction extends AbstractAction
+{
+    /**
+     * @param $params
+     * @return \common_report_Report
+     * @throws \Exception
+     */
+    public function __invoke($params)
+    {
+        if (!isset($params[0])) {
+            throw new \common_exception_MissingParameter('Missing `deliveryId` as a first parameter in ' . static::class);
+        }
+        $task = $this->propagate(new DeliveryDeleteTask());
+        return $task(['deliveryId' => $params[0]]);
+    }
+
+    /**
+     * @return mixed|string
+     */
+    public function jsonSerialize()
+    {
+        return __CLASS__;
+    }
+}

--- a/model/DeliveryAssemblyService.php
+++ b/model/DeliveryAssemblyService.php
@@ -151,7 +151,10 @@ class DeliveryAssemblyService extends OntologyClassService
         $deliveryAssignement->onDelete($assembly);
         /** @var core_kernel_classes_Resource $runtimeResource */
         $runtimeResource = $assembly->getUniquePropertyValue(new core_kernel_classes_Property(self::PROPERTY_DELIVERY_RUNTIME));
-        return $runtimeResource->delete();
+        if ($runtimeResource instanceof core_kernel_classes_Resource) {
+            return $runtimeResource->delete();
+        }
+        return true;
     }
 
     /**

--- a/model/DeliveryAssemblyWrapperService.php
+++ b/model/DeliveryAssemblyWrapperService.php
@@ -29,15 +29,12 @@ class DeliveryAssemblyWrapperService extends ConfigurableService implements Deli
 {
     const SERVICE_ID = 'taoDeliveryRdf/DeliveryAssemblyWrapper';
 
-    /** @var DeliveryAssemblyService */
-    private $deliveryAssemblyService;
-
     /**
      * @inheritdoc
      */
     public function deleteDeliveryData(DeliveryDeleteRequest $request)
     {
-        $service = $this->getServiceLocator()->get(DeliveryAssemblyWrapperService::class);
+        $service = $this->getServiceLocator()->get(DeliveryAssemblyService::class);
         return $service->deleteInstance($request->getDeliveryResource());
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -270,6 +270,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('11.5.0');
         }
 
-        $this->skip('11.5.0', '11.5.1');
+        $this->skip('11.5.0', '11.5.2');
     }
 }

--- a/test/unit/model/DeliveryAssemblyWrapperServiceTest.php
+++ b/test/unit/model/DeliveryAssemblyWrapperServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoDeliveryRdf\test\unit\model;
+
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteRequest;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyWrapperService;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+
+class DeliveryAssemblyWrapperServiceTest extends TestCase
+{
+    /**
+     * @inheritdoc
+     */
+    public function testDeleteDeliveryData()
+    {
+        $request = new DeliveryDeleteRequest('foo');
+        $service = new DeliveryAssemblyWrapperService();
+        $serviceLocator = $this->getServiceLocatorMock([
+            DeliveryAssemblyService::class => $this->getDeliveryAssemblyServiceMock()
+        ]);
+        $service->setServiceLocator($serviceLocator);
+
+        $result = $service->deleteDeliveryData($request);
+        $this->assertTrue($result);
+    }
+
+    private function getDeliveryAssemblyServiceMock()
+    {
+        $service = $this->getMockBuilder(DeliveryAssemblyService::class)->getMock();
+        $service->method('deleteInstance')
+            ->willReturn(true);
+        return $service;
+    }
+}


### PR DESCRIPTION
This change breaks delivery delete functionality: https://github.com/oat-sa/extension-tao-delivery-rdf/commit/72da79c3942414fe79467edbe6569b55f17adab2#diff-a9f2ddc162ccac50f756c3309524e2f5R40

Deletion fails with message: `PHP Fatal error:  Uncaught Error: Call to undefined method oat\taoDeliveryRdf\model\DeliveryAssemblyWrapperService::deleteInstance()`

To test it call the following action:
```
php index.php '\oat\taoDeliveryRdf\model\Delete\DeliveryDeleteAction' '<deliveryId>'
```
Replase `<deliveryId>` with existing delivery uri.