### PR TITLE
Feature/tao 10137/add origin test resource in delivery created event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.6.0',
+  'version'     => '11.7.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -130,6 +130,10 @@ class DeliveryFactory extends ConfigurableService
                 $container = $compiler->getContainer();
             }
             $compilationInstance = $this->createDeliveryResource($deliveryClass, $serviceCall, $container, $properties);
+
+            $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+            $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance, $test));
+
             $report->setData($compilationInstance);
         }
 
@@ -224,8 +228,6 @@ class DeliveryFactory extends ConfigurableService
             $compilationInstance = $deliveryClass->createInstanceWithProperties($properties);
         }
 
-        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
-        $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance));
         return $compilationInstance;
     }
 }

--- a/model/event/DeliveryCreatedEvent.php
+++ b/model/event/DeliveryCreatedEvent.php
@@ -34,15 +34,21 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
     private $delivery;
 
     /**
+     * @var core_kernel_classes_Resource
+     */
+    private $originTest;
+
+    /**
      * @param string $deliveryUri
      * @param string $testUri
      *
      * @throws \core_kernel_persistence_Exception
      */
-    public function __construct(core_kernel_classes_Resource $delivery)
+    public function __construct(core_kernel_classes_Resource $delivery, core_kernel_classes_Resource $originTest)
     {
         $this->deliveryUri = $delivery->getUri();
         $this->delivery = $delivery;
+        $this->originTest= $originTest;
     }
 
     /**
@@ -87,5 +93,10 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
             'deliveryId' => $this->deliveryUri,
             'testId' => $this->delivery->getOnePropertyValue($testProperty)->getUri(),
         ];
+    }
+
+    public function getOriginTest(): core_kernel_classes_Resource
+    {
+        return $this->originTest;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -270,6 +270,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('11.5.0');
         }
         
-        $this->skip('11.5.0', '11.6.0');
+        $this->skip('11.5.0', '11.7.0');
     }
 }

--- a/test/unit/model/event/DeliveryCreatedEventTest.php
+++ b/test/unit/model/event/DeliveryCreatedEventTest.php
@@ -45,7 +45,7 @@ class DeliveryCreatedEventTest extends TestCase
         $this->testResource->method('getUri')->willReturn(self::TEST_URI);
     }
 
-    public function testSerializeForWebhook()
+    public function testSerializeForWebhook(): void
     {
         $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->serializeForWebhook();
@@ -56,7 +56,7 @@ class DeliveryCreatedEventTest extends TestCase
         $this->assertEquals(self::TEST_URI, $result['testId']);
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->jsonSerialize();
@@ -64,7 +64,7 @@ class DeliveryCreatedEventTest extends TestCase
         $this->assertEquals($result['delivery'], self::DELIVERY_URI);
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getName();
@@ -72,14 +72,14 @@ class DeliveryCreatedEventTest extends TestCase
         $this->assertEquals($result, DeliveryCreatedEvent::class);
     }
 
-    public function testGetWebhookEventName()
+    public function testGetWebhookEventName(): void
     {
         $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getWebhookEventName();
         $this->assertEquals('DeliveryCreatedEvent', $result);
     }
 
-    public function testGetUri()
+    public function testGetUri(): void
     {
         $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getDeliveryUri();

--- a/test/unit/model/event/DeliveryCreatedEventTest.php
+++ b/test/unit/model/event/DeliveryCreatedEventTest.php
@@ -32,6 +32,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     /** @var core_kernel_classes_Resource|MockObject */
     private $deliveryMock;
+
     /** @var core_kernel_classes_Resource|MockObject */
     private $testResource;
 
@@ -46,7 +47,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testSerializeForWebhook()
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock);
+        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->serializeForWebhook();
 
         $this->assertArrayHasKey('deliveryId', $result);
@@ -57,7 +58,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testJsonSerialize()
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock);
+        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->jsonSerialize();
         $this->assertArrayHasKey('delivery', $result);
         $this->assertEquals($result['delivery'], self::DELIVERY_URI);
@@ -65,7 +66,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testGetName()
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock);
+        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getName();
 
         $this->assertEquals($result, DeliveryCreatedEvent::class);
@@ -73,14 +74,14 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testGetWebhookEventName()
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock);
+        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getWebhookEventName();
         $this->assertEquals('DeliveryCreatedEvent', $result);
     }
 
     public function testGetUri()
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock);
+        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
         $result = $event->getDeliveryUri();
 
          $this->assertEquals(self::DELIVERY_URI, $result);


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-10137

To avoid unnecessary DB calls in DeliveryCreatedEvent handlers we need origin test resource in the event.