### PR TITLE
Fix/tao 10137/make test optional in delivery created event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.8.0',
+  'version'     => '11.8.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/model/event/DeliveryCreatedEvent.php
+++ b/model/event/DeliveryCreatedEvent.php
@@ -39,10 +39,8 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
     private $originTest;
 
     /**
-     * @param string $deliveryUri
-     * @param string $testUri
-     *
-     * @throws \core_kernel_persistence_Exception
+     * @param core_kernel_classes_Resource $delivery
+     * @param core_kernel_classes_Resource $originTest
      */
     public function __construct(core_kernel_classes_Resource $delivery, ?core_kernel_classes_Resource $originTest =  null)
     {

--- a/model/event/DeliveryCreatedEvent.php
+++ b/model/event/DeliveryCreatedEvent.php
@@ -44,7 +44,7 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
      *
      * @throws \core_kernel_persistence_Exception
      */
-    public function __construct(core_kernel_classes_Resource $delivery, core_kernel_classes_Resource $originTest)
+    public function __construct(core_kernel_classes_Resource $delivery, ?core_kernel_classes_Resource $originTest =  null)
     {
         $this->deliveryUri = $delivery->getUri();
         $this->delivery = $delivery;
@@ -95,7 +95,7 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
         ];
     }
 
-    public function getOriginTest(): core_kernel_classes_Resource
+    public function getOriginTest(): ?core_kernel_classes_Resource
     {
         return $this->originTest;
     }


### PR DESCRIPTION
Made originTest parameter  optional in DeliveryCreatedEvent for backward compatibility.