### PR TITLE
Fix/tao 10137/fix issues when delivery created event triggered without test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.8.1',
+  'version'     => '12.0.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -132,7 +132,7 @@ class DeliveryFactory extends ConfigurableService
             $compilationInstance = $this->createDeliveryResource($deliveryClass, $serviceCall, $container, $properties);
 
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
-            $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance, $test));
+            $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance, $test->getUri()));
 
             $report->setData($compilationInstance);
         }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-10137

Only URI property of `originTest` in DeliveryCreatedEvent is used in event handlers and is serialized. Additionally when DeliveryCreatedEvent is triggered client code doesn't always have test resource or event test uri. Therefore:
- constructor parameter was changed to `string $originTestUri`
- added method to get test uri. If it was not passed as constructor parameter try  to  read delivery property
- if delivery doesn't have  origin  assembly test property return `null` as default value (this case must be properly handled by client code)