### PR TITLE
Feature/tao 10142/remove test from delivery created event

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '11.8.1',
+  'version'     => '12.0.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.15.0',

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -132,7 +132,7 @@ class DeliveryFactory extends ConfigurableService
             $compilationInstance = $this->createDeliveryResource($deliveryClass, $serviceCall, $container, $properties);
 
             $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
-            $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance, $test));
+            $eventManager->trigger(new DeliveryCreatedEvent($compilationInstance));
 
             $report->setData($compilationInstance);
         }

--- a/model/event/DeliveryCreatedEvent.php
+++ b/model/event/DeliveryCreatedEvent.php
@@ -23,7 +23,6 @@ namespace oat\taoDeliveryRdf\model\event;
 
 use core_kernel_classes_Resource;
 use oat\tao\model\webhooks\WebhookSerializableEventInterface;
-use \core_kernel_persistence_Exception;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 
 class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSerializableEventInterface
@@ -34,19 +33,12 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
     private $delivery;
 
     /**
-     * @var core_kernel_classes_Resource
-     */
-    private $originTest;
-
-    /**
      * @param core_kernel_classes_Resource $delivery
-     * @param core_kernel_classes_Resource $originTest
      */
-    public function __construct(core_kernel_classes_Resource $delivery, ?core_kernel_classes_Resource $originTest =  null)
+    public function __construct(core_kernel_classes_Resource $delivery)
     {
         $this->deliveryUri = $delivery->getUri();
         $this->delivery = $delivery;
-        $this->originTest= $originTest;
     }
 
     /**
@@ -82,19 +74,18 @@ class DeliveryCreatedEvent extends AbstractDeliveryEvent implements WebhookSeria
 
     /**
      * @return array
-     * @throws core_kernel_persistence_Exception
      */
-    public function serializeForWebhook()
+    public function serializeForWebhook(): array
     {
-        $testProperty = new \core_kernel_classes_Property(DeliveryAssemblyService::PROPERTY_ORIGIN);
+        $testUri = null;
+        try {
+            $testProperty = new \core_kernel_classes_Property(DeliveryAssemblyService::PROPERTY_ORIGIN);
+            $testUri = $this->delivery->getOnePropertyValue($testProperty)->getUri();
+        } catch (\Throwable $e) {}
+
         return [
             'deliveryId' => $this->deliveryUri,
-            'testId' => $this->delivery->getOnePropertyValue($testProperty)->getUri(),
+            'testId' => $testUri,
         ];
-    }
-
-    public function getOriginTest(): ?core_kernel_classes_Resource
-    {
-        return $this->originTest;
     }
 }

--- a/test/unit/model/event/DeliveryCreatedEventTest.php
+++ b/test/unit/model/event/DeliveryCreatedEventTest.php
@@ -47,7 +47,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testSerializeForWebhook(): void
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
+        $event = new DeliveryCreatedEvent($this->deliveryMock);
         $result = $event->serializeForWebhook();
 
         $this->assertArrayHasKey('deliveryId', $result);
@@ -58,7 +58,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testJsonSerialize(): void
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
+        $event = new DeliveryCreatedEvent($this->deliveryMock);
         $result = $event->jsonSerialize();
         $this->assertArrayHasKey('delivery', $result);
         $this->assertEquals($result['delivery'], self::DELIVERY_URI);
@@ -66,7 +66,7 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testGetName(): void
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
+        $event = new DeliveryCreatedEvent($this->deliveryMock);
         $result = $event->getName();
 
         $this->assertEquals($result, DeliveryCreatedEvent::class);
@@ -74,14 +74,14 @@ class DeliveryCreatedEventTest extends TestCase
 
     public function testGetWebhookEventName(): void
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
+        $event = new DeliveryCreatedEvent($this->deliveryMock);
         $result = $event->getWebhookEventName();
         $this->assertEquals('DeliveryCreatedEvent', $result);
     }
 
     public function testGetUri(): void
     {
-        $event = new DeliveryCreatedEvent($this->deliveryMock, $this->testResource);
+        $event = new DeliveryCreatedEvent($this->deliveryMock);
         $result = $event->getDeliveryUri();
 
          $this->assertEquals(self::DELIVERY_URI, $result);


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-10142

There are cases when delivery resource may be created without test. In this case it's not possible to trigger DeliveryCreatedEvent with test. Therefore test dependency was removed from DeliveryCreatedEvent and test has to be retrieved from delivery resource in event handlers where it's needed.