### PR TITLE
Fix/tao 10399/publish delivery custom properties

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '12.2.0',
+  'version'     => '12.2.1',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.32.1',

--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -87,8 +87,11 @@ class ImportAndCompile extends AbstractTaskAction implements \JsonSerializable
             /** @var \core_kernel_classes_Resource $delivery */
             $delivery = $compilationReport->getData();
             $customParams = $params[self::OPTION_CUSTOM];
-            if (($delivery instanceof \core_kernel_classes_Resource) && $customParams) {
-                $delivery->setPropertiesValues($customParams);
+            if (($delivery instanceof \core_kernel_classes_Resource) && is_array($customParams)) {
+                foreach ($customParams as $rdfKey => $rdfValue) {
+                    $property = $this->getProperty($rdfKey);
+                    $delivery->editPropertyValues($property, $rdfValue);
+                }
             }
             $report->add($compilationReport);
             $report->setData(


### PR DESCRIPTION
Fix for delivery property update

Related to : https://oat-sa.atlassian.net/browse/TAO-10399

Fixed how provided custom properties/values are saved in delivery resource. Problem was that when delivery already has a value for particular property, then providing new value through custom param creates a new property record, not replacing old one.
   
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-publishing/pull/88