### PR TITLE
Fix/tao 10154/set title for import and compile task

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '12.2.1',
+  'version'     => '12.2.2',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.32.1',

--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -195,12 +195,14 @@ class ImportAndCompile extends AbstractTaskAction implements \JsonSerializable
         $fileUri = $action->saveFile($file['tmp_name'], $file['name']);
         /** @var QueueDispatcher $queueDispatcher */
         $queueDispatcher = ServiceManager::getServiceManager()->get(QueueDispatcher::SERVICE_ID);
-
-        return $queueDispatcher->createTask($action, [
+        $taskParameters = [
             self::OPTION_FILE => $fileUri,
             self::OPTION_IMPORTER => $importerId,
             self::OPTION_CUSTOM => $customParams,
             self::OPTION_DELIVERY_LABEL => $deliveryClassLabel,
-        ], null, null, true);
+        ];
+        $taskTitle = __('Import QTI test and create delivery.');;
+
+        return $queueDispatcher->createTask($action, $taskParameters, $taskTitle, null, true);
     }
 }


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-10154

When using `RestTest::compileDeferred()` endpoint to create a delivery task is created and rendered on UI without title.
<img width="408" alt="Screenshot 2020-07-16 at 12 59 30" src="https://user-images.githubusercontent.com/42937157/87663633-6bf38580-c764-11ea-823a-e0a57ad9ce18.png">

Added a title for ImportAndCompile task:
<img width="390" alt="Screenshot 2020-07-16 at 13 00 08" src="https://user-images.githubusercontent.com/42937157/87663652-7746b100-c764-11ea-9242-346a1262f2e7.png">

How to test:
- publish delivery using TAO remote publishing functionality or `RestTest::compileDeferred()` endpoint directly and check task list on target environment.
