### PR TITLE
UNO-392 BREAKING CHANGE: require a major update of `tao`

### DIFF
--- a/helper/TestRunnerFeatureWidget.php
+++ b/helper/TestRunnerFeatureWidget.php
@@ -22,22 +22,20 @@
 
 namespace oat\taoDeliveryRdf\helper;
 
+use common_ext_ExtensionsManager;
 use oat\oatbox\service\ServiceManager;
 use oat\taoTests\models\runner\features\TestRunnerFeatureService;
+use tao_helpers_form_FormElement;
+use taoItems_models_classes_TemplateRenderer;
 
 /**
  * Allow the selection of the Test Runner Features wanted for a specific delivery
  */
-class TestRunnerFeatureWidget extends \tao_helpers_form_FormElement
+class TestRunnerFeatureWidget extends tao_helpers_form_FormElement
 {
-    const WIDGET_TPL = 'views/templates/widgets/testRunnerFeature.tpl.php';
+    public const WIDGET_ID = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#DeliveryTestRunnerFeature';
 
-    /**
-     * A reference to the Widget Definition URI.
-     *
-     * @var string
-     */
-    protected $widget = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#DeliveryTestRunnerFeature';
+    private const WIDGET_TPL = 'views/templates/widgets/testRunnerFeature.tpl.php';
 
     /**
      * Data is stored as a coma-separated list of active test runner features ids
@@ -86,8 +84,8 @@ class TestRunnerFeatureWidget extends \tao_helpers_form_FormElement
             }
         }
 
-        $tpl = \common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf')->getDir() . self::WIDGET_TPL ;
-        $templateRenderer = new \taoItems_models_classes_TemplateRenderer($tpl, [
+        $tpl = common_ext_ExtensionsManager::singleton()->getExtensionById('taoDeliveryRdf')->getDir() . self::WIDGET_TPL ;
+        $templateRenderer = new taoItems_models_classes_TemplateRenderer($tpl, [
             'propLabel'   => _dh($this->getDescription()),
             'choicesList' => $choicesList
         ]);

--- a/manifest.php
+++ b/manifest.php
@@ -20,22 +20,27 @@
  *
  */
 
+
+use oat\taoDeliveryRdf\install\RegisterDeliveryContainerService;
 use oat\taoDeliveryRdf\install\RegisterDeliveryFactoryService;
+use oat\taoDeliveryRdf\scripts\RegisterEvents;
 use oat\taoDeliveryRdf\scripts\install\OverrideRuntime;
 use oat\taoDeliveryRdf\scripts\install\RegisterDeliveryAssemblyWrapperService;
-use oat\taoDeliveryRdf\scripts\install\SetUpQueueTasks;
 use oat\taoDeliveryRdf\scripts\install\RegisterFileSystem;
+use oat\taoDeliveryRdf\scripts\install\SetUpQueueTasks;
+use oat\taoDeliveryRdf\scripts\update\Updater;
+use oat\tao\model\user\TaoRoles;
 
 return [
   'name'        => 'taoDeliveryRdf',
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '12.2.2',
+  'version'     => '13.0.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.32.1',
-        'tao'         => '>=38.3.1',
+        'tao'         => '>=45.0.0',
         'taoGroups'   => '>=4.0.0',
         'taoTests'    => '>=12.1.0',
         'taoQtiTest'  => '>=35.4.0',
@@ -44,8 +49,8 @@ return [
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
     'acl' => [
         ['grant', 'http://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager', ['ext' => 'taoDeliveryRdf']],
-        ['grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoDeliveryRdf', 'mod' => 'RestDelivery']],
-        ['grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoDeliveryRdf', 'mod' => 'RestTest']],
+        ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoDeliveryRdf', 'mod' => 'RestDelivery']],
+        ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoDeliveryRdf', 'mod' => 'RestTest']],
         ['grant', 'http://www.tao.lu/Ontologies/generis.rdf#AnonymousRole','oat\taoDeliveryRdf\controller\Guest@guest'],
     ],
     'install' => [
@@ -55,8 +60,8 @@ return [
         ],
         'php' => [
             __DIR__ . DIRECTORY_SEPARATOR . "install" . DIRECTORY_SEPARATOR . 'registerAssignment.php',
-            'oat\\taoDeliveryRdf\\install\\RegisterDeliveryContainerService',
-            'oat\\taoDeliveryRdf\\scripts\\RegisterEvents',
+            RegisterDeliveryContainerService::class,
+            RegisterEvents::class,
             RegisterDeliveryFactoryService::class,
             OverrideRuntime::class,
             SetUpQueueTasks::class,
@@ -65,18 +70,18 @@ return [
         ]
     ],
     //'uninstall' => array(),
-    'update' => 'oat\\taoDeliveryRdf\\scripts\\update\\Updater',
+    'update' => Updater::class,
     'routes' => [
         '/taoDeliveryRdf' => 'oat\\taoDeliveryRdf\\controller'
     ],
     'constants' => [
         # views directory
-        "DIR_VIEWS" => dirname(__FILE__) . DIRECTORY_SEPARATOR . "views" . DIRECTORY_SEPARATOR,
+        "DIR_VIEWS" => __DIR__ . DIRECTORY_SEPARATOR . "views" . DIRECTORY_SEPARATOR,
 
         #BASE URL (usually the domain root)
         'BASE_URL' => ROOT_URL . 'taoDeliveryRdf/',
     ],
     'extra' => [
-        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
+        'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
     ]
 ];


### PR DESCRIPTION
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) BREAKING CHANGE: require a major update of `tao`
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) chore: use `WIDGET_ID` constant instead of a deprecated `$widget` property to define `TestRunnerFeatureWidget`'s widget URI

⚠️ Depends on `tao-core` [#2609](https://github.com/oat-sa/tao-core/pull/2609).