### PR TITLE
Fix/BSA-227/Create delivery parent tree

### DIFF
--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -22,17 +22,17 @@ declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\controller;
 
-use common_report_Report as Report;
-use tao_helpers_Http as HttpHelper;
+use common_exception_BadRequest as BadRequestException;
 use common_exception_Error as Error;
+use common_exception_MissingParameter as MissingParameterException;
+use common_exception_NotFound as NotFoundException;
+use common_exception_NotImplemented as NotImplementedException;
+use common_report_Report as Report;
 use oat\tao\model\import\ImporterNotFound;
 use oat\tao\model\taskQueue\TaskLogInterface;
-use tao_actions_RestController as RestController;
-use common_exception_NotFound as NotFoundException;
 use oat\taoDeliveryRdf\model\tasks\ImportAndCompile;
-use common_exception_BadRequest as BadRequestException;
-use common_exception_NotImplemented as NotImplementedException;
-use common_exception_MissingParameter as MissingParameterException;
+use tao_actions_RestController as RestController;
+use tao_helpers_Http as HttpHelper;
 
 /**
  * Class RestTest
@@ -48,7 +48,10 @@ class RestTest extends RestController
     public const REST_DELIVERY_PARAMS = 'delivery-params';
     public const REST_DELIVERY_CLASS_LABELS = 'delivery-class-labels';
 
-    /** @deprecated Use \oat\taoDeliveryRdf\controller\RestTest::REST_DELIVERY_CLASS_LABELS instead */
+    /**
+     * @deprecated
+     * @see \oat\taoDeliveryRdf\controller\RestTest::REST_DELIVERY_CLASS_LABELS
+     */
     public const REST_DELIVERY_CLASS_LABEL = 'delivery-class-label';
 
     /**

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -48,6 +48,9 @@ class RestTest extends RestController
     public const REST_DELIVERY_PARAMS = 'delivery-params';
     public const REST_DELIVERY_CLASS_LABELS = 'delivery-class-labels';
 
+    /** @deprecated Use \oat\taoDeliveryRdf\controller\RestTest::REST_DELIVERY_CLASS_LABELS instead */
+    public const REST_DELIVERY_CLASS_LABEL = 'delivery-class-label';
+
     /** @var array */
     private $body;
 

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -51,9 +51,6 @@ class RestTest extends RestController
     /** @deprecated Use \oat\taoDeliveryRdf\controller\RestTest::REST_DELIVERY_CLASS_LABELS instead */
     public const REST_DELIVERY_CLASS_LABEL = 'delivery-class-label';
 
-    /** @var array */
-    private $body;
-
     /**
      * Import test and compile it into delivery
      *

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -15,78 +15,117 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2017-2020 (original work) Open Assessment Technologies SA;
  */
+
+declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\controller;
 
+use common_report_Report as Report;
+use tao_helpers_Http as HttpHelper;
+use common_exception_Error as Error;
 use oat\tao\model\import\ImporterNotFound;
 use oat\tao\model\taskQueue\TaskLogInterface;
+use tao_actions_RestController as RestController;
+use common_exception_NotFound as NotFoundException;
 use oat\taoDeliveryRdf\model\tasks\ImportAndCompile;
+use common_exception_BadRequest as BadRequestException;
+use common_exception_NotImplemented as NotImplementedException;
+use common_exception_MissingParameter as MissingParameterException;
 
 /**
  * Class RestTest
+ *
  * @package oat\taoDeliveryRdf\controller
+ *
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
  */
-class RestTest extends \tao_actions_RestController
+class RestTest extends RestController
 {
-    const REST_IMPORTER_ID = 'importerId';
-    const REST_FILE_NAME = 'testPackage';
-    const REST_DELIVERY_PARAMS = 'delivery-params';
-    const REST_DELIVERY_CLASS_LABEL = 'delivery-class-label';
+    public const REST_IMPORTER_ID = 'importerId';
+    public const REST_FILE_NAME = 'testPackage';
+    public const REST_DELIVERY_PARAMS = 'delivery-params';
+    public const REST_DELIVERY_CLASS_LABELS = 'delivery-class-labels';
+
+    /** @var array */
+    private $body;
 
     /**
      * Import test and compile it into delivery
+     *
+     * @throws Error
+     * @throws MissingParameterException
+     * @throws NotImplementedException
      */
-    public function compileDeferred()
+    public function compileDeferred(): void
     {
         if ($this->getRequestMethod() !== \Request::HTTP_POST) {
-            throw new \common_exception_NotImplemented('Only post method is accepted to compile test');
+            throw new NotImplementedException('Only post method is accepted to compile test');
         }
 
         if (!$this->hasRequestParameter(self::REST_IMPORTER_ID)) {
-            throw new \common_exception_MissingParameter(self::REST_IMPORTER_ID, $this->getRequestURI());
+            throw new MissingParameterException(self::REST_IMPORTER_ID, $this->getRequestURI());
         }
 
-        if (\tao_helpers_Http::hasUploadedFile(self::REST_FILE_NAME)) {
-            $file = \tao_helpers_Http::getUploadedFile(self::REST_FILE_NAME);
-            $importerId = $this->getRequestParameter(self::REST_IMPORTER_ID);
+        if (HttpHelper::hasUploadedFile(self::REST_FILE_NAME)) {
             try {
-                $customParams = [];
-                if ($this->hasRequestParameter(self::REST_DELIVERY_PARAMS)) {
-                    $customParams = $this->getRequestParameter(self::REST_DELIVERY_PARAMS);
-                    $customParams = json_decode(html_entity_decode($customParams), true);
-                }
-                $deliveryClassLabel = '';
-                if ($this->hasRequestParameter(self::REST_DELIVERY_CLASS_LABEL)) {
-                    $deliveryClassLabel = $this->getRequestParameter(self::REST_DELIVERY_CLASS_LABEL);
-                }
-                $task = ImportAndCompile::createTask($importerId, $file, $customParams, $deliveryClassLabel);
+                $importerId = $this->getParameter(self::REST_IMPORTER_ID);
+                $file = HttpHelper::getUploadedFile(self::REST_FILE_NAME);
+                $customParams = $this->getDecodedParameter(self::REST_DELIVERY_PARAMS);
+                $deliveryClassLabels = $this->getDecodedParameter(self::REST_DELIVERY_CLASS_LABELS);
+
+                $task = ImportAndCompile::createTask($importerId, $file, $customParams, $deliveryClassLabels);
             } catch (ImporterNotFound $e) {
-                $this->returnFailure(new \common_exception_NotFound($e->getMessage()));
+                $this->returnFailure(new NotFoundException($e->getMessage()));
             }
-            
+
             $result = ['reference_id' => $task->getId()];
 
             /** @var TaskLogInterface $taskLog */
             $taskLog = $this->getServiceLocator()->get(TaskLogInterface::SERVICE_ID);
-
             $report = $taskLog->getReport($task->getId());
 
-            if (!empty($report)) { //already executed
-                if ($report instanceof \common_report_Report) {
-                    //serialize report to array
-                    $report = json_encode($report);
-                    $report = json_decode($report);
+            if (!empty($report)) {
+                if ($report instanceof Report) {
+                    // Serialize report to array
+                    $report = json_decode(json_encode($report));
                 }
+
                 $result['common_report_Report'] = $report;
             }
 
-            return $this->returnSuccess($result);
+            $this->returnSuccess($result);
         } else {
-            return $this->returnFailure(new \common_exception_BadRequest('Test package file was not given'));
+            $this->returnFailure(new BadRequestException('Test package file was not given'));
         }
+    }
+
+    /**
+     * @param string $name
+     * @param mixed|null $default
+     *
+     * @return string|null
+     */
+    private function getParameter(string $name, $default = null): ?string
+    {
+        if (!isset($this->body)) {
+            $this->body = $this->getPsrRequest()->getParsedBody();
+        }
+
+        return $this->body[$name] ?? $default;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return array
+     */
+    private function getDecodedParameter(string $name): array
+    {
+        return json_decode(
+            html_entity_decode($this->getParameter($name, [])),
+            true
+        );
     }
 }

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -77,7 +77,16 @@ class RestTest extends RestController
                 $importerId = $this->getParameter(self::REST_IMPORTER_ID);
                 $file = HttpHelper::getUploadedFile(self::REST_FILE_NAME);
                 $customParams = $this->getDecodedParameter(self::REST_DELIVERY_PARAMS);
-                $deliveryClassLabels = $this->getDecodedParameter(self::REST_DELIVERY_CLASS_LABELS);
+                $deliveryClassLabels = $this->getParameter(self::REST_DELIVERY_CLASS_LABELS) === null
+                    ? [$this->getParameter(self::REST_DELIVERY_CLASS_LABEL)]
+                    : $this->getDecodedParameter(self::REST_DELIVERY_CLASS_LABELS);
+
+                $deliveryClassLabels = array_filter(
+                    $deliveryClassLabels,
+                    static function ($deliveryClassLabel): bool {
+                        return null !== $deliveryClassLabel;
+                    }
+                );
 
                 $task = ImportAndCompile::createTask($importerId, $file, $customParams, $deliveryClassLabels);
             } catch (ImporterNotFound $e) {

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -109,11 +109,17 @@ class RestTest extends RestController
      */
     private function getParameter(string $name, $default = null): ?string
     {
-        if (!isset($this->body)) {
-            $this->body = $this->getPsrRequest()->getParsedBody();
+        $bodyParameters = $this->getPsrRequest()->getParsedBody();
+
+        if (is_array($bodyParameters) && isset($bodyParameters[$name])) {
+            return $bodyParameters[$name];
         }
 
-        return $this->body[$name] ?? $default;
+        if (is_object($bodyParameters) && property_exists($bodyParameters, $name)) {
+            return $bodyParameters->$name;
+        }
+
+        return $default;
     }
 
     /**

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -123,9 +123,10 @@ class RestTest extends RestController
      */
     private function getDecodedParameter(string $name): array
     {
-        return json_decode(
-            html_entity_decode($this->getParameter($name, [])),
-            true
-        );
+        $data = $this->getParameter($name, []);
+
+        return is_array($data)
+            ? $data
+            : json_decode(html_entity_decode($data), true);
     }
 }

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -31,6 +31,7 @@ use common_report_Report as Report;
 use oat\tao\model\import\ImporterNotFound;
 use oat\tao\model\taskQueue\TaskLogInterface;
 use oat\taoDeliveryRdf\model\tasks\ImportAndCompile;
+use Request;
 use tao_actions_RestController as RestController;
 use tao_helpers_Http as HttpHelper;
 
@@ -63,7 +64,7 @@ class RestTest extends RestController
      */
     public function compileDeferred(): void
     {
-        if ($this->getRequestMethod() !== \Request::HTTP_POST) {
+        if ($this->getRequestMethod() !== Request::HTTP_POST) {
             throw new NotImplementedException('Only post method is accepted to compile test');
         }
 

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -105,9 +105,9 @@ class RestTest extends RestController
      * @param string $name
      * @param mixed|null $default
      *
-     * @return string|null
+     * @return mixed|null
      */
-    private function getParameter(string $name, $default = null): ?string
+    private function getParameter(string $name, $default = null)
     {
         $bodyParameters = $this->getPsrRequest()->getParsedBody();
 
@@ -116,7 +116,7 @@ class RestTest extends RestController
         }
 
         if (is_object($bodyParameters) && property_exists($bodyParameters, $name)) {
-            return $bodyParameters->$name;
+            return $bodyParameters->{$name};
         }
 
         return $default;

--- a/controller/RestTest.php
+++ b/controller/RestTest.php
@@ -89,7 +89,7 @@ class RestTest extends RestController
             if (!empty($report)) {
                 if ($report instanceof Report) {
                     // Serialize report to array
-                    $report = json_decode(json_encode($report));
+                    $report = json_decode(json_encode($report), true);
                 }
 
                 $result['common_report_Report'] = $report;

--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return [
   'label'       => 'Delivery Management',
   'description' => 'Manages deliveries using the ontology',
   'license'     => 'GPL-2.0',
-  'version'     => '13.0.0',
+  'version'     => '13.1.0',
     'author'      => 'Open Assessment Technologies SA',
     'requires'    => [
         'generis'     => '>=12.32.1',

--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -147,8 +147,7 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
         array $file,
         array $customParams = [],
         array $deliveryClassLabels = []
-    ): CallbackTaskInterface
-    {
+    ): CallbackTaskInterface {
         $serviceManager = ServiceManager::getServiceManager();
         $action = new self();
         $action->setServiceLocator($serviceManager);


### PR DESCRIPTION
Relates to: [BSA-227](https://oat-sa.atlassian.net/browse/BSA-227)

**Changes:**
* constant `REST_DELIVERY_CLASS_LABEL` marked as deprecated;
* added new constant `REST_DELIVERY_CLASS_LABELS ` which should be used instead of `REST_DELIVERY_CLASS_LABEL`;
* added method `determineParentClass()` to determine correct parent class in accordance with given array of labels (previously single label used).

**Companion PR:** [#92](https://github.com/oat-sa/extension-tao-publishing/pull/92)