### PR TITLE
feat: added files to zip solution

### DIFF
--- a/model/DataStore/MetaDataDeliverySyncTask.php
+++ b/model/DataStore/MetaDataDeliverySyncTask.php
@@ -96,7 +96,7 @@ class MetaDataDeliverySyncTask extends AbstractAction implements JsonSerializabl
         $queueDispatcher->createTask(
             $this,
             $params,
-            __('Continue try to sync GCP of delivery "%s".', $params['deliveryId'])
+            __('DataStore sync retry for delivery "%s".', $params['deliveryId'])
         );
     }
 

--- a/model/DataStore/PersistDataService.php
+++ b/model/DataStore/PersistDataService.php
@@ -148,19 +148,7 @@ class PersistDataService extends ConfigurableService
 
     private function addMetaDataFile(ZipArchive $zipFile, string $fileNameToAdd, string $content): bool
     {
-        $return = false;
-
-        try {
-            $return = $zipFile->addFromString($fileNameToAdd, $content);
-        } catch (Throwable $exception) {
-            $this->logError(
-                sprintf('Error while adding file %s to the zip file  with message: %s ',
-                    $fileNameToAdd,
-                    $exception->getMessage())
-            );
-        }
-
-        return $return;
+        return $zipFile->addFromString($fileNameToAdd, $content);
     }
 
     private function addMetaDataToArchive(string $zipFile, array $metaData): void

--- a/model/DataStore/PersistDataService.php
+++ b/model/DataStore/PersistDataService.php
@@ -146,7 +146,7 @@ class PersistDataService extends ConfigurableService
         return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
     }
 
-    private function addMetaDataFile($zipFile, string $fileNameToAdd, string $content): bool
+    private function addMetaDataFile(ZipArchive $zipFile, string $fileNameToAdd, string $content): bool
     {
         $return = false;
 
@@ -163,7 +163,7 @@ class PersistDataService extends ConfigurableService
         return $return;
     }
 
-    private function addMetaDataToArchive($zipFile, array $metaData): void
+    private function addMetaDataToArchive(string $zipFile, array $metaData): void
     {
         $zipArchive = new ZipArchive();
 
@@ -176,10 +176,6 @@ class PersistDataService extends ConfigurableService
         $zipArchive->close();
     }
 
-    /**
-     * @param string $deliveryId
-     * @return string
-     */
     private function getZipFileName(string $deliveryId): string
     {
         return sprintf(

--- a/model/DataStore/PersistDataService.php
+++ b/model/DataStore/PersistDataService.php
@@ -33,14 +33,10 @@ use tao_helpers_Uri;
 use tao_models_classes_export_ExportHandler as ExporterInterface;
 use taoQtiTest_models_classes_export_TestExport22;
 use Throwable;
-use ZipArchive;
 
 class PersistDataService extends ConfigurableService
 {
     private const DATA_STORE = 'dataStore';
-    private const DELIVERY_META_DATA_JSON = 'deliveryMetaData.json';
-    private const TEST_META_DATA_JSON = 'testMetaData.json';
-    private const ITEM_META_DATA_JSON = 'itemMetaData.json';
     private const PACKAGE_FILENAME = 'QTIPackage';
     private const ZIP_EXTENSION = '.zip';
     public const  OPTION_EXPORTER_SERVICE = 'exporter_service';
@@ -112,7 +108,7 @@ class PersistDataService extends ConfigurableService
         if (!empty($zipFiles)) {
             foreach ($zipFiles as $zipFile) {
                 $zipFileName = $this->getZipFileName($deliveryId);
-                $this->addMetaDataToArchive($zipFile, $params);
+                $this->getProcessDataService()->process($zipFile, $params);
                 $contents = file_get_contents($zipFile);
 
                 if ($this->getDataStoreFilesystem()->has($zipFileName)) {
@@ -146,22 +142,9 @@ class PersistDataService extends ConfigurableService
         return $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
     }
 
-    private function addMetaDataFile(ZipArchive $zipFile, string $fileNameToAdd, string $content): bool
+    private function getProcessDataService(): ProcessDataService
     {
-        return $zipFile->addFromString($fileNameToAdd, $content);
-    }
-
-    private function addMetaDataToArchive(string $zipFile, array $metaData): void
-    {
-        $zipArchive = new ZipArchive();
-
-        $zipArchive->open($zipFile);
-
-        $this->addMetaDataFile($zipArchive, self::DELIVERY_META_DATA_JSON, json_encode($metaData['deliveryMetaData']));
-        $this->addMetaDataFile($zipArchive, self::TEST_META_DATA_JSON, json_encode($metaData['testMetaData']));
-        $this->addMetaDataFile($zipArchive, self::ITEM_META_DATA_JSON, json_encode($metaData['itemMetaData']));
-
-        $zipArchive->close();
+        return $this->getServiceLocator()->get(ProcessDataService::class);
     }
 
     private function getZipFileName(string $deliveryId): string

--- a/model/DataStore/ProcessDataService.php
+++ b/model/DataStore/ProcessDataService.php
@@ -27,12 +27,10 @@ use ZipArchive;
 
 class ProcessDataService extends ConfigurableService
 {
-
     private const DELIVERY_META_DATA_JSON = 'deliveryMetaData.json';
     private const TEST_META_DATA_JSON = 'testMetaData.json';
     private const ITEM_META_DATA_JSON = 'itemMetaData.json';
     public const  OPTION_ZIP_ARCHIVE_SERVICE = 'zipArchive';
-
 
     public function process(string $zipFile, array $metaData): void
     {

--- a/model/DataStore/ProcessDataService.php
+++ b/model/DataStore/ProcessDataService.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\DataStore;
+
+use oat\oatbox\service\ConfigurableService;
+use ZipArchive;
+
+class ProcessDataService extends ConfigurableService
+{
+
+    private const DELIVERY_META_DATA_JSON = 'deliveryMetaData.json';
+    private const TEST_META_DATA_JSON = 'testMetaData.json';
+    private const ITEM_META_DATA_JSON = 'itemMetaData.json';
+    public const  OPTION_ZIP_ARCHIVE_SERVICE = 'zipArchive';
+
+
+    public function process(string $zipFile, array $metaData): void
+    {
+        $zipArchive = $this->getZipArchive();
+
+        $zipArchive->open($zipFile);
+
+        $this->saveMetaData($zipArchive, self::DELIVERY_META_DATA_JSON, json_encode($metaData['deliveryMetaData']));
+        $this->saveMetaData($zipArchive, self::TEST_META_DATA_JSON, json_encode($metaData['testMetaData']));
+        $this->saveMetaData($zipArchive, self::ITEM_META_DATA_JSON, json_encode($metaData['itemMetaData']));
+
+        $zipArchive->close();
+    }
+
+    private function saveMetaData(ZipArchive $zipFile, string $fileNameToAdd, string $content): void
+    {
+        $zipFile->addFromString($fileNameToAdd, $content);
+    }
+
+    private function getZipArchive(): ZipArchive
+    {
+        $zipArchive = $this->getOption(self::OPTION_ZIP_ARCHIVE_SERVICE);
+
+        return $zipArchive ?? new ZipArchive();
+    }
+}

--- a/test/unit/model/DataStore/PersistDataServiceTest.php
+++ b/test/unit/model/DataStore/PersistDataServiceTest.php
@@ -78,12 +78,6 @@ class PersistDataServiceTest extends TestCase
 
         $this->exporterHelper->expects($this->once())->method('export')->willReturn(true);
 
-        $this->fileSystem->expects($this->exactly(3))->method('has')->willReturn(false);
-        $this->fileSystem->expects($this->exactly(3))->method('write')->willReturn(true);
-
-        $this->filesystemService->expects($this->once())->method('getFileSystem')
-            ->willReturn($this->fileSystem);
-
         $this->subject->persist($params);
     }
 

--- a/test/unit/model/DataStore/ProcessDataServiceTest.php
+++ b/test/unit/model/DataStore/ProcessDataServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021  (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\DataStore;
+
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\DataStore\ProcessDataService;
+use PHPUnit\Framework\MockObject\MockObject;
+use ZipArchive;
+
+class ProcessDataServiceTest extends TestCase
+{
+    /** @var MockObject|ZipArchive */
+    private $zipArchive;
+
+    /** @var ProcessDataService */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->zipArchive = $this->createMock(ZipArchive::class);
+
+        $this->subject = new ProcessDataService(
+            [ProcessDataService::OPTION_ZIP_ARCHIVE_SERVICE => $this->zipArchive]
+        );
+    }
+
+    public function testProcess(): void
+    {
+        $zipFile = 'bogus/zipFile.zip';
+        $this->zipArchive->expects($this->once())->method('open')->with($zipFile);
+        $this->zipArchive->expects($this->exactly(3))->method('addFromString');
+        $this->zipArchive->expects($this->once())->method('close');
+        $metaData = [
+            'deliveryMetaData' => 'deliveryMetaData',
+            'testMetaData' => 'testMetaData',
+            'itemMetaData' => 'itemMetaData',
+        ];
+        $this->subject->process($zipFile, $metaData);
+    }
+}


### PR DESCRIPTION
Info:
Added files to zip solution
- we will not add the pubsub event as this is not required and was confirmed by reporting team

task:
https://oat-sa.atlassian.net/browse/AUT-428
 
 ENV: http://datastore-gcp-flow.playground.kitchen.it.taocloud.org:48141/
Google bucket :https://console.cloud.google.com/storage/browser/datastorebucketconstruct/dataStore

zip outcome inside the dataStore folder: 
[QTIPackage.zip](https://github.com/oat-sa/extension-tao-delivery-rdf/files/6501188/QTIPackage.zip)

config required : 
config/generis/filesystem.conf.php
```
,
        'dataStore' => 'default'
```
