### PR TITLE
Feature TR-1357 client defined delivery URI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oat-sa/extension-tao-group" : ">=7.0.0",
         "oat-sa/extension-tao-item" : ">=11.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",
-        "oat-sa/extension-tao-testqti" : ">=41.0.0"
+        "oat-sa/extension-tao-testqti" : "dev-feature/TR-1357/expose-imported-resource-clean-up-method as 41.9.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
         "oat-sa/generis" : ">=14.0.0",
         "oat-sa/tao-core" : ">=47.0.0",
         "oat-sa/extension-tao-delivery" : ">=15.0.0",
-        "oat-sa/extension-tao-test" : ">=15.0.0",
         "oat-sa/extension-tao-group" : ">=7.0.0",
+        "oat-sa/extension-tao-item" : ">=11.0.0",
+        "oat-sa/extension-tao-test" : ">=15.0.0",
         "oat-sa/extension-tao-testqti" : ">=41.0.0"
     },
     "autoload" : {
         "psr-4" : {
             "oat\\taoDeliveryRdf\\" : ""
         }
-    } 
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "oat-sa/extension-tao-group" : ">=7.0.0",
         "oat-sa/extension-tao-item" : ">=11.0.0",
         "oat-sa/extension-tao-test" : ">=15.0.0",
-        "oat-sa/extension-tao-testqti" : "dev-feature/TR-1357/expose-imported-resource-clean-up-method as 41.9.0"
+        "oat-sa/extension-tao-testqti" : ">=41.10.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/manifest.php
+++ b/manifest.php
@@ -29,6 +29,7 @@ use oat\taoDeliveryRdf\scripts\install\OverrideRuntime;
 use oat\taoDeliveryRdf\scripts\install\RegisterDeliveryAssemblyWrapperService;
 use oat\taoDeliveryRdf\scripts\install\RegisterFileSystem;
 use oat\taoDeliveryRdf\scripts\install\SetUpQueueTasks;
+use oat\taoDeliveryRdf\scripts\tools\SetDeliveryNamespace;
 use oat\taoDeliveryRdf\scripts\update\Updater;
 use oat\tao\model\user\TaoRoles;
 
@@ -59,7 +60,8 @@ return [
             SetUpQueueTasks::class,
             RegisterDeliveryAssemblyWrapperService::class,
             RegisterFileSystem::class,
-            RegisterDataStoreServices::class
+            RegisterDataStoreServices::class,
+            SetDeliveryNamespace::class,
         ]
     ],
     'update' => Updater::class,

--- a/migrations/Version202106221057211286_taoDeliveryRdf.php
+++ b/migrations/Version202106221057211286_taoDeliveryRdf.php
@@ -24,11 +24,7 @@ final class Version202106221057211286_taoDeliveryRdf extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addReport(
-            $this->propagate(
-                new SetDeliveryNamespace()
-            )(
-                []
-            )
+            $this->propagate(new SetDeliveryNamespace())([])
         );
 
         $this->addReport(

--- a/migrations/Version202106221057211286_taoDeliveryRdf.php
+++ b/migrations/Version202106221057211286_taoDeliveryRdf.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoDeliveryRdf\model\Delivery\Business\Contract\DeliveryNamespaceRegistryInterface;
+use oat\taoDeliveryRdf\scripts\tools\SetDeliveryNamespace;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202106221057211286_taoDeliveryRdf extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register ' . DeliveryNamespaceRegistryInterface::SERVICE_ID;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addReport(
+            $this->propagate(
+                new SetDeliveryNamespace()
+            )(
+                []
+            )
+        );
+
+        $this->addReport(
+            Report::createInfo(
+                sprintf(
+                    'You may run `php index.php \'%s\' -n <delivery_namespace>` in order to override a Delivery namespace',
+                    SetDeliveryNamespace::class
+                )
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->getServiceManager()->unregister(DeliveryNamespaceRegistryInterface::SERVICE_ID);
+
+        $this->addReport(
+            Report::createSuccess('Unregistered ' . DeliveryNamespaceRegistryInterface::SERVICE_ID)
+        );
+    }
+}

--- a/model/Delete/DeliveryDeleteRequest.php
+++ b/model/Delete/DeliveryDeleteRequest.php
@@ -21,27 +21,35 @@
 
 namespace oat\taoDeliveryRdf\model\Delete;
 
-use core_kernel_classes_Resource;
+use core_kernel_classes_Resource as KernelResource;
 
 class DeliveryDeleteRequest
 {
     /** @var string  */
     private $deliveryId;
 
-    /**
-     * DeliveryDeleteRequest constructor.
-     * @param $deliveryId string
-     */
-    public function __construct($deliveryId)
+    /** @var bool */
+    private $isRecursive = false;
+
+    public function __construct(string $deliveryId)
     {
         $this->deliveryId = $deliveryId;
     }
 
-    /**
-     * @return core_kernel_classes_Resource
-     */
-    public function getDeliveryResource()
+    public function getDeliveryResource(): KernelResource
     {
-        return new core_kernel_classes_Resource($this->deliveryId);
+        return new KernelResource($this->deliveryId);
+    }
+
+    public function isRecursive(): bool
+    {
+        return $this->isRecursive;
+    }
+
+    public function setIsRecursive(): self
+    {
+        $this->isRecursive = true;
+
+        return $this;
     }
 }

--- a/model/Delete/DeliveryDeleteService.php
+++ b/model/Delete/DeliveryDeleteService.php
@@ -248,6 +248,10 @@ class DeliveryDeleteService extends ConfigurableService
     {
         $delivery = $this->request->getDeliveryResource();
 
+        if (!$delivery->exists()) {
+            return;
+        }
+
         $test = $delivery->getUniquePropertyValue(
             $delivery->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN)
         );

--- a/model/Delete/DeliveryDeleteService.php
+++ b/model/Delete/DeliveryDeleteService.php
@@ -24,14 +24,20 @@ namespace oat\taoDeliveryRdf\model\Delete;
 use common_report_Report;
 use common_ext_ExtensionsManager as ExtensionsManager;
 use core_kernel_classes_Resource;
+use core_kernel_classes_Resource as KernelResource;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\Monitoring;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteRequest;
 use oat\taoDelivery\model\execution\Delete\DeliveryExecutionDeleteService;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoQtiTest\models\TestSessionService;
 use oat\taoResultServer\models\classes\ResultManagement;
 use oat\taoResultServer\models\classes\ResultServerService;
+use taoItems_models_classes_ItemsService as ItemService;
+use taoQtiTest_models_classes_QtiTestService as QtiTestService;
+use taoTests_models_classes_TestsService as TestService;
 
 class DeliveryDeleteService extends ConfigurableService
 {
@@ -43,6 +49,9 @@ class DeliveryDeleteService extends ConfigurableService
 
     /** @var common_report_Report  */
     protected $report;
+
+    /** @var DeliveryDeleteRequest */
+    private $request;
 
     /**
      * DeliveryDeleteService constructor.
@@ -66,6 +75,8 @@ class DeliveryDeleteService extends ConfigurableService
      */
     public function execute(DeliveryDeleteRequest $request, $byChunk = false)
     {
+        $this->request = $request;
+
         $delivery = $request->getDeliveryResource();
 
         $this->report = common_report_Report::createInfo('Deleting Delivery: ' . $delivery->getUri());
@@ -76,9 +87,10 @@ class DeliveryDeleteService extends ConfigurableService
             : count($executions);
         if ($byChunk && $executions && count($executions) > $executionsLimit) {
             $executionsForDeleting = array_slice($executions, 0, $executionsLimit);
-            $this->deleteDeliveryExecutions($delivery, $executionsForDeleting);
+            $this->deleteDeliveryExecutions($executionsForDeleting);
         } else {
-            $this->deleteDeliveryExecutions($delivery, $executions);
+            $this->deleteDeliveryExecutions($executions);
+            $this->deleteLinkedResources();
             return $this->deleteDelivery($request);
         }
         return true;
@@ -86,7 +98,8 @@ class DeliveryDeleteService extends ConfigurableService
 
     /**
      * @param core_kernel_classes_Resource $deliveryResource
-     * @return array|\oat\taoDelivery\model\execution\DeliveryExecution[]
+     *
+     * @return array|DeliveryExecution[]
      * @throws \common_exception_Error
      * @throws \common_exception_NoImplementation
      * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
@@ -172,6 +185,21 @@ class DeliveryDeleteService extends ConfigurableService
         return $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID);
     }
 
+    protected function getQtiTestService(): QtiTestService
+    {
+        return $this->getServiceLocator()->get(QtiTestService::class);
+    }
+
+    protected function getItemService(): ItemService
+    {
+        return $this->getServiceLocator()->get(ItemService::class);
+    }
+
+    protected function getTestService(): TestService
+    {
+        return $this->getServiceLocator()->get(TestService::class);
+    }
+
     /**
      * @return DeliveryDelete[]
      * @throws \common_exception_Error
@@ -216,13 +244,31 @@ class DeliveryDeleteService extends ConfigurableService
         );
     }
 
+    private function deleteLinkedResources(): void
+    {
+        $delivery = $this->request->getDeliveryResource();
+
+        $test = $delivery->getUniquePropertyValue(
+            $delivery->getProperty(DeliveryAssemblyService::PROPERTY_ORIGIN)
+        );
+
+        $itemService = $this->getItemService();
+
+        foreach ($this->getQtiTestService()->getItems($test) as $item) {
+            $itemService->deleteResource($item);
+        }
+
+        $this->getTestService()->deleteResource($test);
+    }
+
     /**
-     * @param core_kernel_classes_Resource $delivery
-     * @param $executions
+     * @param DeliveryExecution[] $executions
      * @throws \common_exception_Error
      */
-    private function deleteDeliveryExecutions(\core_kernel_classes_Resource $delivery, $executions)
+    private function deleteDeliveryExecutions(array $executions): void
     {
+        $delivery = $this->request->getDeliveryResource();
+
         /** @var DeliveryExecutionDeleteService $deliveryExecutionDeleteService */
         $deliveryExecutionDeleteService = $this->getServiceLocator()->get(DeliveryExecutionDeleteService::SERVICE_ID);
 
@@ -247,7 +293,7 @@ class DeliveryDeleteService extends ConfigurableService
      * @return bool
      * @throws \common_exception_Error
      */
-    public function hasDeliveryExecutions(\core_kernel_classes_Resource $delivery)
+    public function hasDeliveryExecutions(KernelResource $delivery)
     {
         $executions = $this->getDeliveryExecutions($delivery);
         return !empty($executions);

--- a/model/Delivery/Business/Contract/DeliveryNamespaceRegistryInterface.php
+++ b/model/Delivery/Business/Contract/DeliveryNamespaceRegistryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\Delivery\Business\Contract;
+
+use oat\taoDeliveryRdf\model\Delivery\Business\Domain\DeliveryNamespace;
+
+interface DeliveryNamespaceRegistryInterface
+{
+    public const SERVICE_ID = 'taoDeliveryRdf/DeliveryNamespaceRegistry';
+
+    public function get(): ?DeliveryNamespace;
+}

--- a/model/Delivery/Business/Domain/DeliveryNamespace.php
+++ b/model/Delivery/Business/Domain/DeliveryNamespace.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\Delivery\Business\Domain;
+
+final class DeliveryNamespace
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = rtrim($value, '#');
+    }
+
+    public function equals(self $deliveryNamespace): bool
+    {
+        return (string)$this === (string)$deliveryNamespace;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/model/Delivery/DataAccess/DeliveryNamespaceRegistry.php
+++ b/model/Delivery/DataAccess/DeliveryNamespaceRegistry.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\Delivery\DataAccess;
+
+use InvalidArgumentException;
+use oat\tao\model\service\InjectionAwareService;
+use oat\taoDeliveryRdf\model\Delivery\Business\Domain\DeliveryNamespace;
+use oat\taoDeliveryRdf\model\Delivery\Business\Contract\DeliveryNamespaceRegistryInterface;
+
+final class DeliveryNamespaceRegistry extends InjectionAwareService implements DeliveryNamespaceRegistryInterface
+{
+    /** @var DeliveryNamespace */
+    private $deliveryNamespace;
+    /** @var ?DeliveryNamespace */
+    private $localNamespace;
+
+    public function __construct(DeliveryNamespace $localNamespace, DeliveryNamespace $deliveryNamespace = null)
+    {
+        parent::__construct();
+
+        $this->localNamespace    = $localNamespace;
+        $this->deliveryNamespace = $deliveryNamespace;
+
+        $this->validate();
+    }
+
+    private function validate(): void
+    {
+        if (null === $this->deliveryNamespace) {
+            return;
+        }
+
+        if ($this->deliveryNamespace->equals($this->localNamespace)) {
+            throw new InvalidArgumentException(
+                "Overridden namespace value must be different from a local one, \"$this->deliveryNamespace\" given"
+            );
+        }
+    }
+
+    public function get(): ?DeliveryNamespace
+    {
+        return $this->deliveryNamespace;
+    }
+}

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -76,7 +76,6 @@ class DeliveryFactory extends ConfigurableService
     public const OPTION_INITIAL_PROPERTIES_MAP = 'initialPropertiesMap';
     public const OPTION_INITIAL_PROPERTIES_MAP_VALUES = 'values';
     public const OPTION_INITIAL_PROPERTIES_MAP_URI = 'uri';
-    public const OPTION_NAMESPACE = 'namespace';
 
     public const PROPERTY_DELIVERY_COMPILE_TASK = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryCompileTask';
 

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -238,7 +238,7 @@ class DeliveryFactory extends ConfigurableService
 
         if ('' === $deliveryId) {
             throw new RuntimeException(
-                sprintf('%s must not be empty.', DeliveryAssemblyService::PROPERTY_ASSESSMENT_PROJECT_ID)
+                sprintf('%s must not be empty', DeliveryAssemblyService::PROPERTY_ASSESSMENT_PROJECT_ID)
             );
         }
 

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -34,6 +34,8 @@ use core_kernel_classes_Class as KernelClass;
 use oat\tao\helpers\form\ValidationRuleRegistry;
 use oat\oatbox\event\EventManager;
 use oat\taoDelivery\model\container\delivery\AbstractContainer;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteRequest;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
 use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
 use oat\taoDelivery\model\container\delivery\ContainerProvider;
 use RuntimeException;
@@ -240,7 +242,12 @@ class DeliveryFactory extends ConfigurableService
             );
         }
 
-        $delivery = $deliveryClass->getResource("{$this->getNamespace()}#$deliveryId");
+        $this->getDeliveryDeleteService()
+            ->execute(
+                $this->createDeliverDeleteRequest($deliveryId)
+            );
+
+        $delivery = $deliveryClass->getResource($this->createNamespacedDeliveryId($deliveryId));
 
         $delivery->setPropertiesValues([OntologyRdf::RDF_TYPE => $deliveryClass]);
 
@@ -267,8 +274,24 @@ class DeliveryFactory extends ConfigurableService
         return $namespace;
     }
 
+    private function createNamespacedDeliveryId(string $deliveryId): string
+    {
+        return "{$this->getNamespace()}#$deliveryId";
+    }
+
+    private function createDeliverDeleteRequest(string $deliveryId): DeliveryDeleteRequest
+    {
+        return (new DeliveryDeleteRequest($this->createNamespacedDeliveryId($deliveryId)))
+            ->setIsRecursive();
+    }
+
     private function getEventManager(): EventManager
     {
         return $this->getServiceLocator()->get(EventManager::class);
+    }
+
+    private function getDeliveryDeleteService(): DeliveryDeleteService
+    {
+        return $this->getServiceLocator()->get(DeliveryDeleteService::class);
     }
 }

--- a/model/DeliveryFactory.php
+++ b/model/DeliveryFactory.php
@@ -236,7 +236,7 @@ class DeliveryFactory extends ConfigurableService
     ): KernelResource {
         $deliveryId = trim($additionalParameters[DeliveryAssemblyService::PROPERTY_ASSESSMENT_PROJECT_ID] ?? '');
 
-        if (!$deliveryId) {
+        if ('' === $deliveryId) {
             throw new RuntimeException(
                 sprintf('%s must not be empty.', DeliveryAssemblyService::PROPERTY_ASSESSMENT_PROJECT_ID)
             );

--- a/model/export/AssemblyExporterService.php
+++ b/model/export/AssemblyExporterService.php
@@ -150,7 +150,7 @@ class AssemblyExporterService extends ConfigurableService
             $data['dir'][$id] = $directory->getPrefix();
         }
 
-        $runtime = $compiledDelivery->getUniquePropertyValue($this->getProperty(DeliveryAssemblyService::PROPERTY_DELIVERY_RUNTIME));
+        $runtime = $compiledDelivery->getResource($this->getProperty(DeliveryAssemblyService::PROPERTY_DELIVERY_RUNTIME));
         $serviceCall = tao_models_classes_service_ServiceCall::fromResource($runtime);
         $data['runtime'] = base64_encode($serviceCall->serializeToString());
         $rdfData = $this->rdfExporter->getRdfString([$compiledDelivery]);

--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -72,6 +72,9 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
     {
         $this->checkParams($params);
 
+        /** @var string[] $customParams */
+        $customParams = $params[self::OPTION_CUSTOM];
+
         $file = $this->getFileReferenceSerializer()->unserializeFile($params[self::OPTION_FILE]);
         $report = null;
 
@@ -94,7 +97,7 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
             $label = 'Delivery of ' . $test->getLabel();
             $parent = $this->checkSubClasses($params[self::OPTION_DELIVERY_LABELS]);
             $deliveryFactory = $this->getServiceManager()->get(DeliveryFactory::SERVICE_ID);
-            $compilationReport = $deliveryFactory->create($parent, $test, $label);
+            $compilationReport = $deliveryFactory->create($parent, $test, $label, null, $customParams);
 
             if ($compilationReport->getType() == Report::TYPE_ERROR) {
                 Logger::i(
@@ -104,7 +107,6 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
             }
             /** @var Resource $delivery */
             $delivery = $compilationReport->getData();
-            $customParams = $params[self::OPTION_CUSTOM];
 
             if ($delivery instanceof Resource && is_array($customParams)) {
                 foreach ($customParams as $rdfKey => $rdfValue) {

--- a/scripts/tools/DeleteDeliveryScript.php
+++ b/scripts/tools/DeleteDeliveryScript.php
@@ -1,15 +1,29 @@
 <?php
 
 /**
- * Copyright (c) 2017 Open Assessment Technologies, S.A.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA;
  */
+
+declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\scripts\tools;
 
-use common_report_Report;
-use oat\oatbox\extension\AbstractAction;
-use common_report_Report as Report;
+use Exception;
+use oat\oatbox\reporting\Report;
 use oat\oatbox\extension\script\ScriptAction;
 use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteRequest;
 use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
@@ -22,17 +36,12 @@ use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
  */
 class DeleteDeliveryScript extends ScriptAction
 {
-    /**
-     * @var common_report_Report
-     */
-    private $report;
-
-    protected function showTime()
+    protected function showTime(): bool
     {
         return true;
     }
 
-    protected function provideUsage()
+    protected function provideUsage(): array
     {
         return [
             'prefix' => 'h',
@@ -41,7 +50,7 @@ class DeleteDeliveryScript extends ScriptAction
         ];
     }
 
-    protected function provideOptions()
+    protected function provideOptions(): array
     {
         return [
             'delivery' => [
@@ -53,18 +62,14 @@ class DeleteDeliveryScript extends ScriptAction
         ];
     }
 
-    protected function provideDescription()
+    protected function provideDescription(): string
     {
         return 'TAO Delivery - Delete Delivery';
     }
 
-    /**
-     * @return Report
-     * @throws \common_exception_Error
-     */
-    protected function run()
+    protected function run(): Report
     {
-        $this->report = common_report_Report::createInfo('Deleting Delivery ...');
+        $report = Report::createInfo('Deleting Delivery ...');
 
         /** @var DeliveryDeleteService $deliveryDeleteService */
         $deliveryDeleteService = $this->getServiceLocator()->get(DeliveryDeleteService::SERVICE_ID);
@@ -72,12 +77,12 @@ class DeleteDeliveryScript extends ScriptAction
         $deliveryId = $this->getOption('delivery');
         try {
             $deliveryDeleteService->execute(new DeliveryDeleteRequest($deliveryId));
-            $this->report->add($deliveryDeleteService->getReport());
-        } catch (\Exception $exception) {
-            $this->report->add(common_report_Report::createFailure('Failing deleting delivery: ' . $deliveryId));
-            $this->report->add(common_report_Report::createFailure($exception->getMessage()));
+            $report->add($deliveryDeleteService->getReport());
+        } catch (Exception $exception) {
+            $report->add(Report::createError('Failing deleting delivery: ' . $deliveryId));
+            $report->add(Report::createError($exception->getMessage()));
         }
 
-        return $this->report;
+        return $report;
     }
 }

--- a/scripts/tools/DeleteDeliveryScript.php
+++ b/scripts/tools/DeleteDeliveryScript.php
@@ -32,6 +32,7 @@ use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
  * sudo -u www-data php index.php 'oat\taoDeliveryRdf\scripts\tools\DeleteDeliveryScript'
  *
  * Class TerminateSession
+ *
  * @package oat\taoDeliveryRdf\scripts\tools
  */
 class DeleteDeliveryScript extends ScriptAction
@@ -44,21 +45,27 @@ class DeleteDeliveryScript extends ScriptAction
     protected function provideUsage(): array
     {
         return [
-            'prefix' => 'h',
-            'longPrefix' => 'help',
-            'description' => 'Prints a help statement'
+            'prefix'      => 'h',
+            'longPrefix'  => 'help',
+            'description' => 'Prints a help statement',
         ];
     }
 
     protected function provideOptions(): array
     {
         return [
-            'delivery' => [
-                'prefix' => 'd',
-                'longPrefix' => 'delivery',
-                'required' => true,
-                'description' => 'A delivery ID.'
-            ]
+            'delivery'  => [
+                'prefix'      => 'd',
+                'longPrefix'  => 'delivery',
+                'required'    => true,
+                'description' => 'A delivery ID',
+            ],
+            'recursive' => [
+                'prefix'      => 'r',
+                'longPrefix'  => 'recursive',
+                'flag'        => true,
+                'description' => 'Remove all the linked resources such as Tests or Items',
+            ],
         ];
     }
 
@@ -72,11 +79,11 @@ class DeleteDeliveryScript extends ScriptAction
         $report = Report::createInfo('Deleting Delivery ...');
 
         /** @var DeliveryDeleteService $deliveryDeleteService */
-        $deliveryDeleteService = $this->getServiceLocator()->get(DeliveryDeleteService::SERVICE_ID);
+        $deliveryDeleteService = $this->getServiceLocator()->get(DeliveryDeleteService::class);
 
         $deliveryId = $this->getOption('delivery');
         try {
-            $deliveryDeleteService->execute(new DeliveryDeleteRequest($deliveryId));
+            $deliveryDeleteService->execute($this->createDeliveryDeleteRequest());
             $report->add($deliveryDeleteService->getReport());
         } catch (Exception $exception) {
             $report->add(Report::createError('Failing deleting delivery: ' . $deliveryId));
@@ -84,5 +91,16 @@ class DeleteDeliveryScript extends ScriptAction
         }
 
         return $report;
+    }
+
+    private function createDeliveryDeleteRequest(): DeliveryDeleteRequest
+    {
+        $deliveryDeleteRequest = new DeliveryDeleteRequest($this->getOption('delivery'));
+
+        if ($this->getOption('recursive')) {
+            $deliveryDeleteRequest->setIsRecursive();
+        }
+
+        return $deliveryDeleteRequest;
     }
 }

--- a/scripts/tools/SetDeliveryNamespace.php
+++ b/scripts/tools/SetDeliveryNamespace.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\scripts\tools;
+
+use Exception;
+use InvalidArgumentException;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+use oat\taoDeliveryRdf\model\DeliveryFactory;
+
+/**
+ * Usage:
+ *
+ * sudo -u www-data php index.php 'oat\taoDeliveryRdf\scripts\tools\SetDeliveryNamespace' -n https://taotesting.com
+ */
+class SetDeliveryNamespace extends ScriptAction
+{
+    protected function provideUsage(): array
+    {
+        return [
+            'prefix'      => 'h',
+            'longPrefix'  => 'help',
+            'description' => 'Prints this message',
+        ];
+    }
+
+    protected function provideOptions(): array
+    {
+        return [
+            'namespace' => [
+                'prefix'      => 'n',
+                'longPrefix'  => 'namespace',
+                'required'    => true,
+                'description' => 'A custom namespace for remotely published Delivery resources',
+            ],
+        ];
+    }
+
+    protected function run(): Report
+    {
+        $namespace = $this->getNamespace();
+
+        $deliveryFactory = $this->getDeliveryFactory();
+        $deliveryFactory->setOption(DeliveryFactory::OPTION_NAMESPACE, $namespace);
+
+        try {
+            $this->getServiceManager()->register($deliveryFactory::SERVICE_ID, $deliveryFactory);
+        } catch (Exception $exception) {
+            return Report::createError(
+                "Failed to set \"$namespace\" Delivery namespace.",
+                null,
+                [Report::createInfo($exception->getMessage())]
+            );
+        }
+
+        return Report::createSuccess("Registered \"$namespace\" Delivery namespace.");
+    }
+
+    protected function provideDescription(): string
+    {
+        return 'TAO DeliveryRDF - Set up remotely published Delivery resource namespace';
+    }
+
+    private function getNamespace(): string
+    {
+        $namespace = rtrim($this->getOption('namespace'), '#');
+
+        if ($namespace === LOCAL_NAMESPACE) {
+            throw new InvalidArgumentException(
+                "Overridden namespace value must be different from a local one, \"$namespace\" given"
+            );
+        }
+
+        return $namespace;
+    }
+
+    private function getDeliveryFactory(): DeliveryFactory
+    {
+        return $this->getServiceLocator()->get(DeliveryFactory::class);
+    }
+}

--- a/test/unit/model/Delivery/Business/Domain/DeliveryNamespaceTest.php
+++ b/test/unit/model/Delivery/Business/Domain/DeliveryNamespaceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Delivery\Business\Domain;
+
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\Delivery\Business\Domain\DeliveryNamespace;
+
+class DeliveryNamespaceTest extends TestCase
+{
+    /**
+     * @param string            $expected
+     * @param DeliveryNamespace $sut
+     *
+     * @dataProvider validDeliveryNamespaces
+     */
+    public function testNamespaceValueNormalizationAndComparison(string $expected, DeliveryNamespace $sut): void
+    {
+        static::assertEquals($expected, $sut);
+        static::assertTrue($sut->equals(new DeliveryNamespace($expected)));
+    }
+
+    public function validDeliveryNamespaces(): array
+    {
+        return [
+            'uri'                   => ['https://taotesting.com', new DeliveryNamespace('https://taotesting.com')],
+            'fragmentContainingUri' => ['https://taotesting.com', new DeliveryNamespace('https://taotesting.com#')],
+        ];
+    }
+}

--- a/test/unit/model/Delivery/DataAccess/DeliveryNamespaceRegistryTest.php
+++ b/test/unit/model/Delivery/DataAccess/DeliveryNamespaceRegistryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Delivery\DataAccess;
+
+use InvalidArgumentException;
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\Delivery\Business\Domain\DeliveryNamespace;
+use oat\taoDeliveryRdf\model\Delivery\DataAccess\DeliveryNamespaceRegistry;
+
+class DeliveryNamespaceRegistryTest extends TestCase
+{
+    public function testDifferentDeliveryNamespace(): void
+    {
+        $deliveryNamespace = new DeliveryNamespace('https://taotesting.com');
+
+        $sut = new DeliveryNamespaceRegistry(
+            new DeliveryNamespace('https://hub.taotesting.com'),
+            $deliveryNamespace
+        );
+
+        static::assertSame(
+            $deliveryNamespace,
+            $sut->get()
+        );
+    }
+
+    public function testNullDeliveryNamespace(): void
+    {
+        $sut = new DeliveryNamespaceRegistry(
+            new DeliveryNamespace('https://hub.taotesting.com')
+        );
+
+        static::assertNull(
+            $sut->get()
+        );
+    }
+
+    public function testSameDeliveryNamespace(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $deliveryNamespace = new DeliveryNamespace('https://taotesting.com');
+
+        new DeliveryNamespaceRegistry(
+            clone $deliveryNamespace,
+            $deliveryNamespace
+        );
+    }
+}

--- a/test/unit/scripts/tools/DeleteDeliveryScriptTest.php
+++ b/test/unit/scripts/tools/DeleteDeliveryScriptTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\scripts\tools;
+
+use Exception;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\reporting\Report;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteRequest;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
+use oat\taoDeliveryRdf\scripts\tools\DeleteDeliveryScript;
+
+class DeleteDeliveryScriptTest extends TestCase
+{
+    private const DELIVERY_ID = 'https://www.taotesting.com/#1';
+
+    /** @var DeleteDeliveryScript */
+    private $sut;
+
+    /** @var MockObject|DeliveryDeleteService */
+    private $deliveryDeleteServiceMock;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->deliveryDeleteServiceMock = $this->createMock(DeliveryDeleteService::class);
+
+        $this->sut = new DeleteDeliveryScript();
+        $this->sut->setServiceLocator(
+            $this->createServiceLocatorMock()
+        );
+    }
+
+    public function testDeleteDelivery(): void
+    {
+        $this->assertDeliveryDeleteServiceCall(
+            $this->createDeliveryDeleteRequest()
+        );
+
+        $this->assertReportContainsNoError(
+            ($this->sut)(['--delivery', self::DELIVERY_ID])
+        );
+    }
+
+    public function testDeleteDeliveryRecursively(): void
+    {
+        $this->assertDeliveryDeleteServiceCall(
+            $this->createDeliveryDeleteRequest(true)
+        );
+
+        $this->assertReportContainsNoError(
+            ($this->sut)(['--delivery', self::DELIVERY_ID, '-r'])
+        );
+    }
+
+    public function testDeleteDeliveryWithException(): void
+    {
+        $this->assertDeliveryDeleteServiceCall(
+            $this->createDeliveryDeleteRequest(),
+            new Exception('test')
+        );
+
+        $this->assertReportContainsError(
+            ($this->sut)(['--delivery', self::DELIVERY_ID])
+        );
+    }
+
+    private function createServiceLocatorMock(): ServiceLocatorInterface
+    {
+        $serviceLocatorMock = $this->createMock(ServiceLocatorInterface::class);
+
+        $serviceLocatorMock
+            ->method('get')
+            ->willReturnMap(
+                [
+                    [DeliveryDeleteService::class, $this->deliveryDeleteServiceMock],
+                ]
+            );
+
+        return $serviceLocatorMock;
+    }
+
+    private function assertDeliveryDeleteServiceCall(
+        DeliveryDeleteRequest $request,
+        Exception $expectedException = null
+    ): void {
+        $this->deliveryDeleteServiceMock
+            ->expects(static::once())
+            ->method('execute')
+            ->with($request)
+            ->will(
+                $expectedException
+                    ? static::throwException($expectedException)
+                    : static::returnValue(true)
+            );
+
+        $this->deliveryDeleteServiceMock
+            ->method('getReport')
+            ->willReturn(
+                Report::createSuccess('test')
+            );
+    }
+
+    private function createDeliveryDeleteRequest(bool $isRecursive = false): DeliveryDeleteRequest
+    {
+        $deliveryDeleteRequest = new DeliveryDeleteRequest(self::DELIVERY_ID);
+
+        if ($isRecursive) {
+            $deliveryDeleteRequest->setIsRecursive();
+        }
+
+        return $deliveryDeleteRequest;
+    }
+
+    private function assertReportContainsNoError(Report $report): void
+    {
+        static::assertFalse(
+            $report->containsError()
+        );
+    }
+
+    private function assertReportContainsError(Report $report): void
+    {
+        static::assertTrue(
+            $report->containsError()
+        );
+    }
+}


### PR DESCRIPTION
# [TR-1357](https://oat-sa.atlassian.net/browse/TR-1357)

- chore: impose `srict_types=1` on `DeleteDeliveryScript.php`
- chore: add return types to `oat\taoDeliveryRdf\scripts\tools\DeleteDeliveryScript` methods
- chore: stop using a deprecated `common_report_Report` witin `oat\taoDeliveryRdf\scripts\tools\DeleteDeliveryScript
- feat: add `isRecursive` property to `DeliveryDeleteRequest` in order to control the deletion scope
- feat: add `-r` flag to `DeleteDeliveryScript` to trigger recursive Delivery data deletion
- chore: add an explicit dependency on `oat-sa/extension-tao-item`
- feat: optionally recursively delete all the linked delivery resources via `DeliveryDeleteService`
- feat: add `namespace` property to `DeliveryDeleteService`, allowing to override a Delivery resource URI
- feat: upon receiving a remote publication, replace a delivery with the same ID and all the resources linked to it
- fix: clear Items and Test resources and data in case of a remote publication failure
- feat: implement `SetDeliveryNamespace` script, allowing to redefine remotely published Delivery resources' namespace
- fix: `oat\taoDeliveryRdf\model\export\AssemblyExporterService::doExportCompiledDelivery()`
- feat: introduce `DeliveryNamespaceRegistryInterface` and its implementation to store an overridden value of a Delivery namespace
- chore: register `DeliveryNamespaceRegistryInterface` implementation
- chore: utilize `DeliveryNamespaceRegistryInterface` implementation to retrieve a remotely published Delivery namespace

## ⚠️ Requires
- [x] https://github.com/oat-sa/extension-tao-testqti/pull/2047

## How to test

**⚠️ Important note ⚠️**
The feature has already been deployed to an internal QA environment. So, if you don't want to spend time setting it up locally, please refer to [this comment](https://oat-sa.atlassian.net/browse/TR-1357?focusedCommentId=139528) in Jira.

1. Have a regular tao-community instance deployed
2. Apply this feature branch on top
3. Run `sudo -u www-data php index.php 'oat\taoDeliveryRdf\scripts\tools\SetDeliveryNamespace' -n https://taotesting.com` to apply a custom namespace for remotely published Delivery resources
4. Set up another tao-community instance
5. Install [`taoPublishing`](https://github.com/oat-sa/extension-tao-publishing) extension on top of it
6. Follow its [README.md](https://github.com/oat-sa/extension-tao-publishing/blob/master/README.md) to finish a set up
7. Set up a Remote Environment connection on the newly created instance
![image](https://user-images.githubusercontent.com/2943256/122580227-0552a800-d056-11eb-91ee-9cb88ba6f152.png)
Make sure to set the first instance's nginx container name as a `Root URL` in case you're utilizing the docker-stack
8. Create a Local Delivery
9. Set its `Assessment Project Id`
![image](https://user-images.githubusercontent.com/2943256/122580516-54004200-d056-11eb-93c3-ee5c0ce112d6.png)
10. Save the Local Delivery
11. Publish it to the Remote instance
12. You should be getting a Remote Delivery with a predefined URI
![image](https://user-images.githubusercontent.com/2943256/122581914-da695380-d057-11eb-9c45-3009db4103ea.png)

Now if you attempt to re-publish a Delivery with the same `Assessment Project Id`, it will completely _overwrite_ a Remote Delivery
