### PR TITLE
TR-1446 fix: skip compact test data conversion when formats match

### DIFF
--- a/model/assembly/CompiledTestConverterFactory.php
+++ b/model/assembly/CompiledTestConverterFactory.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2019-2021  (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoDeliveryRdf\model\assembly;
@@ -29,14 +29,15 @@ use oat\taoQtiTest\models\XmlCompilationDataService;
 
 class CompiledTestConverterFactory extends ConfigurableService
 {
-    const COMPILED_TEST_FORMAT_XML = 'xml';
-    const COMPILED_TEST_FORMAT_PHP = 'php';
+    const COMPILED_TEST_FORMAT_XML            = 'xml';
+    const COMPILED_TEST_FORMAT_PHP            = 'php';
     const COMPILED_TEST_FORMAT_PHP_SERIALIZED = 'php_serialized';
+
     /**
-         * @param $outputTestFormat
-         * @return CompiledTestConverterService
-         * @throws UnsupportedCompiledTestFormatException
-         */
+     * @param $outputTestFormat
+     * @return CompiledTestConverterService
+     * @throws UnsupportedCompiledTestFormatException
+     */
     public function createConverter($outputTestFormat)
     {
         if (!is_string($outputTestFormat)) {
@@ -58,19 +59,21 @@ class CompiledTestConverterFactory extends ConfigurableService
         $outputTestFormat = strtolower(trim($outputTestFormat));
         switch ($outputTestFormat) {
             case self::COMPILED_TEST_FORMAT_PHP:
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             $outputCompilationService = new PhpCodeCompilationDataService();
+                $outputCompilationService = new PhpCodeCompilationDataService();
 
                 break;
             case self::COMPILED_TEST_FORMAT_PHP_SERIALIZED:
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         $outputCompilationService = new PhpSerializationCompilationDataService();
+                $outputCompilationService = new PhpSerializationCompilationDataService();
 
                 break;
             case self::COMPILED_TEST_FORMAT_XML:
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         $outputCompilationService = new XmlCompilationDataService();
+                $outputCompilationService = new XmlCompilationDataService();
 
                 break;
             default:
-                throw new UnsupportedCompiledTestFormatException("Unsupported compiled test format provided: {$outputTestFormat}");
+                throw new UnsupportedCompiledTestFormatException(
+                    "Unsupported compiled test format provided: {$outputTestFormat}"
+                );
         }
 
         return $this->propagate($outputCompilationService);

--- a/model/assembly/CompiledTestConverterFactory.php
+++ b/model/assembly/CompiledTestConverterFactory.php
@@ -35,7 +35,7 @@ class CompiledTestConverterFactory extends ConfigurableService
 
     /**
      * @param $outputTestFormat
-     * @return CompiledTestConverterService
+     * @return CompiledTestConverterService|null
      * @throws UnsupportedCompiledTestFormatException
      */
     public function createConverter($outputTestFormat)
@@ -45,7 +45,13 @@ class CompiledTestConverterFactory extends ConfigurableService
         }
 
         $outputCompilationService = $this->getOutputCompilationService($outputTestFormat);
+        /** @var CompilationDataService $systemCompilationService */
         $systemCompilationService = $this->getServiceLocator()->get(CompilationDataService::SERVICE_ID);
+
+        if (get_class($outputCompilationService) === get_class($systemCompilationService)) {
+            return null;
+        }
+
         return new CompiledTestConverterService($systemCompilationService, $outputCompilationService);
     }
 

--- a/model/export/AssemblyExporterService.php
+++ b/model/export/AssemblyExporterService.php
@@ -144,7 +144,7 @@ class AssemblyExporterService extends ConfigurableService
         $directories = $compiledDelivery->getPropertyValues($this->getProperty(DeliveryAssemblyService::PROPERTY_DELIVERY_DIRECTORY));
         foreach ($directories as $id) {
             $directory = $this->getServiceLocator()->get(ServiceFileStorage::SERVICE_ID)->getDirectoryById($id);
-            foreach ($this->assemblyFilesReader->getFiles($directory) as $filePath => $fileStream) {
+            foreach ($this->getAssemblyFilesReader()->getFiles($directory) as $filePath => $fileStream) {
                 tao_helpers_File::addFilesToZip($zipArchive, $fileStream, $filePath);
             }
             $data['dir'][$id] = $directory->getPrefix();
@@ -177,7 +177,10 @@ class AssemblyExporterService extends ConfigurableService
         /** @var CompiledTestConverterFactory $compiledTestConverterFactory */
         $compiledTestConverterFactory = $this->getServiceLocator()->get(CompiledTestConverterFactory::class);
         $converter = $compiledTestConverterFactory->createConverter($outputTestFormat);
-        $this->getAssemblyFilesReader()->setCompiledTestConverter($converter);
+
+        if ($converter) {
+            $this->getAssemblyFilesReader()->setCompiledTestConverter($converter);
+        }
     }
 
     /**

--- a/test/unit/model/assembly/CompiledTestConverterFactoryTest.php
+++ b/test/unit/model/assembly/CompiledTestConverterFactoryTest.php
@@ -83,6 +83,29 @@ class CompiledTestConverterFactoryTest extends TestCase
     }
 
     /**
+     * @param string $format
+     * @param string|CompilationDataService $compilationDataServiceClassName
+     * @throws UnsupportedCompiledTestFormatException
+     *
+     * @dataProvider dataProviderTestCreateConverterReturnsCompiledTestConverter
+     */
+    public function testCreateConverterReturnsNullWhenNoConversionIsNeeded(
+        string $format,
+        string $compilationDataServiceClassName
+    ): void {
+        $this->object->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    CompilationDataService::SERVICE_ID => new $compilationDataServiceClassName(),
+                    LoggerService::SERVICE_ID          => $this->createMock(LoggerService::class),
+                ]
+            )
+        );
+
+        $this->assertNull($this->object->createConverter($format));
+    }
+
+    /**
      * @return array
      */
     public function dataProviderTestCreateConverterFailsIfParameterNotString()


### PR DESCRIPTION
- chore: reformat `oat\taoDeliveryRdf\model\assembly\CompiledTestConverterFactory`
- fix: skip `compact-test` conversion upon export in case the file already has an appropriate format

This PR fixes a very nasty side-effect of a Delivery export, leading to a `compact-test` file being _removed_ in case the Delivery compilation data is exported in a `php` format.

## How to test

1. Publish a local Delivery Assembly
2. Run `php index.php "oat\taoDeliveryRdf\scripts\tools\ExportDeliveryAssembly" -uri  <delivery_id> -out <writable_directory>/<file_name>.zip -format php` to export a Delivery
3. Make sure the .zip contains `compact-test.php`