### PR TITLE
TR-1848 fix: missing runtime definition of an exported assembly

### DIFF
--- a/model/export/AssemblyExporterService.php
+++ b/model/export/AssemblyExporterService.php
@@ -150,9 +150,13 @@ class AssemblyExporterService extends ConfigurableService
             $data['dir'][$id] = $directory->getPrefix();
         }
 
-        $runtime = $compiledDelivery->getResource($this->getProperty(DeliveryAssemblyService::PROPERTY_DELIVERY_RUNTIME));
-        $serviceCall = tao_models_classes_service_ServiceCall::fromResource($runtime);
-        $data['runtime'] = base64_encode($serviceCall->serializeToString());
+        $runtime = $compiledDelivery->getOnePropertyValue(
+            $this->getProperty(DeliveryAssemblyService::PROPERTY_DELIVERY_RUNTIME)
+        );
+        $serviceCall = $runtime instanceof core_kernel_classes_Resource
+            ? tao_models_classes_service_ServiceCall::fromResource($runtime)
+            : tao_models_classes_service_ServiceCall::fromString((string)$runtime);
+        $data['runtime'] = base64_encode(json_encode($serviceCall));
         $rdfData = $this->rdfExporter->getRdfString([$compiledDelivery]);
         if (!$zipArchive->addFromString(self::DELIVERY_RDF_FILENAME, $rdfData)) {
             throw new common_Exception('Unable to add metadata to exported delivery assembly');


### PR DESCRIPTION
## [TR-1848](https://oat-sa.atlassian.net/browse/TR-1848)

fix: missing assembly runtime service-call definition export as json

### How to test

1. Publish a Delivery
2. Export it via `php index.php 'oat\taoDeliveryRdf\scripts\tools\ExportDeliveryAssembly' -uri <delivery_uri> -out <name>.zip`
3. Make sure `manifest.json` contains base64-encoded `runtime` definition