### PR TITLE
TR-1661 feature: clear assemblies and their resources

### DIFF
--- a/model/Delete/DeliveryDeleteRequest.php
+++ b/model/Delete/DeliveryDeleteRequest.php
@@ -19,17 +19,23 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\taoDeliveryRdf\model\Delete;
 
 use core_kernel_classes_Resource as KernelResource;
 
 class DeliveryDeleteRequest
 {
-    /** @var string  */
+    private const SCOPE_DELIVERY   = 1 << 0;
+    private const SCOPE_EXECUTIONS = 1 << 2;
+    private const SCOPE_RESOURCES  = 1 << 3;
+
+    /** @var string */
     private $deliveryId;
 
-    /** @var bool */
-    private $isRecursive = false;
+    /** @var int */
+    private $scope = self::SCOPE_DELIVERY | self::SCOPE_EXECUTIONS;
 
     public function __construct(string $deliveryId)
     {
@@ -41,15 +47,37 @@ class DeliveryDeleteRequest
         return new KernelResource($this->deliveryId);
     }
 
+    public function isDeliveryRemovalRequested(): bool
+    {
+        return $this->hasInScope(self::SCOPE_DELIVERY);
+    }
+
+    public function isExecutionsRemovalRequested(): bool
+    {
+        return $this->hasInScope(self::SCOPE_EXECUTIONS);
+    }
+
     public function isRecursive(): bool
     {
-        return $this->isRecursive;
+        return $this->hasInScope(self::SCOPE_RESOURCES);
     }
 
     public function setIsRecursive(): self
     {
-        $this->isRecursive = true;
+        $this->scope |= self::SCOPE_RESOURCES;
 
         return $this;
+    }
+
+    public function setDeliveryExecutionsOnly(): self
+    {
+        $this->scope = self::SCOPE_EXECUTIONS;
+
+        return $this;
+    }
+
+    private function hasInScope(int $scope): bool
+    {
+        return (bool)($this->scope & $scope);
     }
 }

--- a/model/Delete/DeliveryDeleteService.php
+++ b/model/Delete/DeliveryDeleteService.php
@@ -140,6 +140,10 @@ class DeliveryDeleteService extends ConfigurableService
      */
     protected function deleteDelivery()
     {
+        if (!$this->request->isDeliveryRemovalRequested()) {
+            return true;
+        }
+
         $services = $this->getDeliveryDeleteService();
 
         foreach ($services as $service) {
@@ -274,6 +278,10 @@ class DeliveryDeleteService extends ConfigurableService
      */
     private function deleteDeliveryExecutions(array $executions): void
     {
+        if (!$this->request->isExecutionsRemovalRequested()) {
+            return;
+        }
+
         $delivery = $this->request->getDeliveryResource();
 
         /** @var DeliveryExecutionDeleteService $deliveryExecutionDeleteService */

--- a/model/Delete/DeliveryDeleteService.php
+++ b/model/Delete/DeliveryDeleteService.php
@@ -246,6 +246,10 @@ class DeliveryDeleteService extends ConfigurableService
 
     private function deleteLinkedResources(): void
     {
+        if (!$this->request->isRecursive()) {
+            return;
+        }
+
         $delivery = $this->request->getDeliveryResource();
 
         if (!$delivery->exists()) {

--- a/model/Delete/DeliveryDeleteService.php
+++ b/model/Delete/DeliveryDeleteService.php
@@ -77,7 +77,7 @@ class DeliveryDeleteService extends ConfigurableService
     {
         $this->request = $request;
 
-        $delivery = $request->getDeliveryResource();
+        $delivery = $this->request->getDeliveryResource();
 
         $this->report = common_report_Report::createInfo('Deleting Delivery: ' . $delivery->getUri());
         $executions   = $this->getDeliveryExecutions($delivery);
@@ -91,7 +91,7 @@ class DeliveryDeleteService extends ConfigurableService
         } else {
             $this->deleteDeliveryExecutions($executions);
             $this->deleteLinkedResources();
-            return $this->deleteDelivery($request);
+            return $this->deleteDelivery();
         }
         return true;
     }
@@ -135,17 +135,16 @@ class DeliveryDeleteService extends ConfigurableService
     }
 
     /**
-     * @param DeliveryDeleteRequest $request
      * @return bool
      * @throws \Exception
      */
-    protected function deleteDelivery(DeliveryDeleteRequest $request)
+    protected function deleteDelivery()
     {
         $services = $this->getDeliveryDeleteService();
 
         foreach ($services as $service) {
             try {
-                $deleted = $service->deleteDeliveryData($request);
+                $deleted = $service->deleteDeliveryData($this->request);
                 if ($deleted) {
                     $this->report->add(common_report_Report::createSuccess(
                         'Delete delivery Service: ' . get_class($service) . ' data has been deleted.'

--- a/model/DeliveryAssemblyService.php
+++ b/model/DeliveryAssemblyService.php
@@ -23,8 +23,6 @@ namespace oat\taoDeliveryRdf\model;
 
 use core_kernel_classes_Resource;
 use \core_kernel_classes_Property;
-use oat\generis\model\kernel\persistence\smoothsql\search\filter\Filter;
-use oat\generis\model\kernel\persistence\smoothsql\search\filter\FilterOperator;
 use oat\taoDeliveryRdf\model\event\DeliveryRemovedEvent;
 use tao_models_classes_service_ServiceCall;
 use oat\taoDelivery\model\RuntimeService;
@@ -103,7 +101,7 @@ class DeliveryAssemblyService extends OntologyClassService
     /**
      * Returns all assemblies marked as active
      *
-     * @return array
+     * @return core_kernel_classes_Resource[]
      */
     public function getAllAssemblies()
     {

--- a/scripts/tools/CleanUp.php
+++ b/scripts/tools/CleanUp.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\scripts\tools;
+
+use core_kernel_classes_Resource as KernelResource;
+use oat\oatbox\reporting\Report;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+
+/**
+ * sudo -u www-data php index.php 'oat\taoDeliveryRdf\scripts\tools\CleanUp' -d <delivery_to_keep_0>,<delivery_to_keep_1>
+ *
+ * Class CleanUp
+ *
+ * @package oat\taoDeliveryRdf\scripts\tools
+ */
+final class CleanUp extends ScriptAction
+{
+    public const OPTION_DELIVERIES = 'deliveries';
+
+    protected function showTime(): bool
+    {
+        return true;
+    }
+
+    protected function provideUsage(): array
+    {
+        return [
+            'prefix'      => 'h',
+            'longPrefix'  => 'help',
+            'description' => 'Prints a help statement',
+        ];
+    }
+
+    protected function provideOptions(): array
+    {
+        return [
+            self::OPTION_DELIVERIES => [
+                'prefix'      => 'd',
+                'longPrefix'  => self::OPTION_DELIVERIES,
+                'required'    => true,
+                'description' => 'A comma-separated list of Deliveries to keep on the instance, all the other Deliveries will be removed.',
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return 'TAO Delivery - Clean up';
+    }
+
+    protected function run(): Report
+    {
+        $deliveriesToKeepMap = $this->denormalizeDeliveriesToKeep();
+
+        $report = Report::createInfo('Cleaning up ...');
+
+        foreach ($this->getDeliveryAssemblyService()->getAllAssemblies() as $assembly) {
+            $deliveryRemovalParameters = $this->createBaseDeliveryRemovalParameters($assembly);
+            $deliveryRemovalParameters[] = $this->createScriptArgument(
+                isset($deliveriesToKeepMap[$assembly->getUri()])
+                    ? DeleteDeliveryScript::OPTION_EXECUTIONS_ONLY
+                    : DeleteDeliveryScript::OPTION_RECURSIVE
+            );
+
+            $report->add(
+                $this->propagate(new DeleteDeliveryScript())($deliveryRemovalParameters)
+            );
+        }
+
+        return $report;
+    }
+
+    private function denormalizeDeliveriesToKeep(): array
+    {
+        return array_flip(explode(',', $this->getOption(self::OPTION_DELIVERIES)));
+    }
+
+    private function createBaseDeliveryRemovalParameters(KernelResource $assembly): array
+    {
+        return [
+            $this->createScriptArgument(DeleteDeliveryScript::OPTION_DELIVERY),
+            $assembly->getUri()
+        ];
+    }
+
+    private function createScriptArgument(string $argument): string
+    {
+        return "--$argument";
+    }
+
+    private function getDeliveryAssemblyService(): DeliveryAssemblyService
+    {
+        return $this->getServiceLocator()->get(DeliveryAssemblyService::class);
+    }
+}

--- a/scripts/tools/DeleteDeliveryScript.php
+++ b/scripts/tools/DeleteDeliveryScript.php
@@ -31,12 +31,16 @@ use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteService;
 /**
  * sudo -u www-data php index.php 'oat\taoDeliveryRdf\scripts\tools\DeleteDeliveryScript'
  *
- * Class TerminateSession
+ * Class DeleteDeliveryScript
  *
  * @package oat\taoDeliveryRdf\scripts\tools
  */
 class DeleteDeliveryScript extends ScriptAction
 {
+    public const OPTION_DELIVERY        = 'delivery';
+    public const OPTION_RECURSIVE       = 'recursive';
+    public const OPTION_EXECUTIONS_ONLY = 'executionsOnly';
+
     protected function showTime(): bool
     {
         return true;
@@ -54,17 +58,23 @@ class DeleteDeliveryScript extends ScriptAction
     protected function provideOptions(): array
     {
         return [
-            'delivery'  => [
+            self::OPTION_DELIVERY => [
                 'prefix'      => 'd',
-                'longPrefix'  => 'delivery',
+                'longPrefix'  => self::OPTION_DELIVERY,
                 'required'    => true,
                 'description' => 'A delivery ID',
             ],
-            'recursive' => [
+            self::OPTION_RECURSIVE => [
                 'prefix'      => 'r',
-                'longPrefix'  => 'recursive',
+                'longPrefix'  => self::OPTION_RECURSIVE,
                 'flag'        => true,
                 'description' => 'Remove all the linked resources such as Tests or Items',
+            ],
+            self::OPTION_EXECUTIONS_ONLY => [
+                'prefix'      => 'e',
+                'longPrefix'  => self::OPTION_EXECUTIONS_ONLY,
+                'flag'        => true,
+                'description' => 'Remove only the delivery executions of the specified Delivery',
             ],
         ];
     }
@@ -81,7 +91,7 @@ class DeleteDeliveryScript extends ScriptAction
         /** @var DeliveryDeleteService $deliveryDeleteService */
         $deliveryDeleteService = $this->getServiceLocator()->get(DeliveryDeleteService::class);
 
-        $deliveryId = $this->getOption('delivery');
+        $deliveryId = $this->getOption(self::OPTION_DELIVERY);
         try {
             $deliveryDeleteService->execute($this->createDeliveryDeleteRequest());
             $report->add($deliveryDeleteService->getReport());
@@ -95,9 +105,13 @@ class DeleteDeliveryScript extends ScriptAction
 
     private function createDeliveryDeleteRequest(): DeliveryDeleteRequest
     {
-        $deliveryDeleteRequest = new DeliveryDeleteRequest($this->getOption('delivery'));
+        $deliveryDeleteRequest = new DeliveryDeleteRequest($this->getOption(self::OPTION_DELIVERY));
 
-        if ($this->getOption('recursive')) {
+        if ($this->getOption(self::OPTION_EXECUTIONS_ONLY)) {
+            $deliveryDeleteRequest->setDeliveryExecutionsOnly();
+        }
+
+        if ($this->getOption(self::OPTION_RECURSIVE)) {
             $deliveryDeleteRequest->setIsRecursive();
         }
 

--- a/test/unit/model/Delete/DeliveryDeleteRequestTest.php
+++ b/test/unit/model/Delete/DeliveryDeleteRequestTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Delete;
+
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\Delete\DeliveryDeleteRequest;
+
+class DeliveryDeleteRequestTest extends TestCase
+{
+    private const DELIVERY_ID = 'testDeliveryId';
+
+    /** @var DeliveryDeleteRequest */
+    private $sut;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->sut = new DeliveryDeleteRequest(self::DELIVERY_ID);
+    }
+
+    public function testGetDeliveryResource(): void
+    {
+        static::assertSame(
+            self::DELIVERY_ID,
+            $this->sut->getDeliveryResource()->getUri()
+        );
+    }
+
+    public function testDefaultScope(): void
+    {
+        static::assertTrue(
+            $this->sut->isDeliveryRemovalRequested()
+        );
+        static::assertTrue(
+            $this->sut->isExecutionsRemovalRequested()
+        );
+        static::assertFalse(
+            $this->sut->isRecursive()
+        );
+    }
+
+    public function testScopeWithResourcesRemovalRequest(): void
+    {
+        $this->sut->setIsRecursive();
+
+        static::assertTrue(
+            $this->sut->isDeliveryRemovalRequested()
+        );
+        static::assertTrue(
+            $this->sut->isExecutionsRemovalRequested()
+        );
+        static::assertTrue(
+            $this->sut->isRecursive()
+        );
+    }
+
+    public function testScopeWithDeliveryExecutionRemovalRequest(): void
+    {
+        $this->sut->setDeliveryExecutionsOnly();
+
+        static::assertFalse(
+            $this->sut->isDeliveryRemovalRequested()
+        );
+        static::assertTrue(
+            $this->sut->isExecutionsRemovalRequested()
+        );
+        static::assertFalse(
+            $this->sut->isRecursive()
+        );
+    }
+}

--- a/test/unit/scripts/tools/DeleteDeliveryScriptTest.php
+++ b/test/unit/scripts/tools/DeleteDeliveryScriptTest.php
@@ -78,6 +78,28 @@ class DeleteDeliveryScriptTest extends TestCase
         );
     }
 
+    public function testDeleteDeliveryExecutionsOnly(): void
+    {
+        $this->assertDeliveryDeleteServiceCall(
+            $this->createDeliveryDeleteRequest(false, true)
+        );
+
+        $this->assertReportContainsNoError(
+            ($this->sut)(['--delivery', self::DELIVERY_ID, '-e'])
+        );
+    }
+
+    public function testDeleteDeliveryExecutionsAndLinkedResources(): void
+    {
+        $this->assertDeliveryDeleteServiceCall(
+            $this->createDeliveryDeleteRequest(true, true)
+        );
+
+        $this->assertReportContainsNoError(
+            ($this->sut)(['--delivery', self::DELIVERY_ID, '-e', '-r'])
+        );
+    }
+
     public function testDeleteDeliveryWithException(): void
     {
         $this->assertDeliveryDeleteServiceCall(
@@ -126,9 +148,15 @@ class DeleteDeliveryScriptTest extends TestCase
             );
     }
 
-    private function createDeliveryDeleteRequest(bool $isRecursive = false): DeliveryDeleteRequest
-    {
+    private function createDeliveryDeleteRequest(
+        bool $isRecursive = false,
+        bool $isDeliveryExecutionsOnly = false
+    ): DeliveryDeleteRequest {
         $deliveryDeleteRequest = new DeliveryDeleteRequest(self::DELIVERY_ID);
+
+        if ($isDeliveryExecutionsOnly) {
+            $deliveryDeleteRequest->setDeliveryExecutionsOnly();
+        }
 
         if ($isRecursive) {
             $deliveryDeleteRequest->setIsRecursive();


### PR DESCRIPTION
# [TR-1661](https://oat-sa.atlassian.net/browse/TR-1661)

- fix: delete linked delivery resources only when replacing a Delivery completely, or running a recursive delivery removal script
- feat: introduce bitmap-based atomic delivery-delete scopes into `DeliveryDeleteRequest`
- chore: use `$request` property instead of passing around a `DeliveryDeleteRequest` object in `DeliveryDeleteService`
- feat: configurable Delivery resources/executions/assembly removal scope by `DeliveryDeleteService`
- chore: apply a proper return type to the `DeliveryAssemblyService::getAllAssemblies()` method's DocBlock
- feat: extend `DeleteDeliveryScript` to allow only linked Delivery Executions' removal
- feat: implement `CleanUp` script allowing to clean up an ingestion environment, leaving only the approved list of Deliveries, and wiping all the other Deliveries along with their linked resources (Tests and Items)

## How to test
1. Have multiple Items created
2. Author a few Tests, using different Items
3. Publish those Tests locally
4. Run `php index.php 'oat\taoDeliveryRdf\scripts\tools\CleanUp' -d <delivery_to_keep_0>,<delivery_to_keep_1>`
5. Make sure all the Deliveries, except the ones specified when running a clean-up scripts were removed, as well as their linked Tests and Items
6. Make sure all the Delivery Executions were removed