### PR TITLE
Fix TR-1576 catch and report remote compilation errors

### DIFF
--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -122,7 +122,20 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
             $report->setData(['delivery-uri' => $delivery->getUri()]);
 
             return $report;
+        } catch (Exception $e) {
+            Logger::singleton()->handleException($e);
         } catch (Throwable $e) {
+            Logger::f($e->getMessage(), [
+                Logger::CONTEXT_EXCEPTION => get_class($e),
+                Logger::CONTEXT_ERROR_FILE => $e->getFile(),
+                Logger::CONTEXT_ERROR_LINE => $e->getLine(),
+                Logger::CONTEXT_TRACE => $e->getTrace()
+            ]);
+        } finally {
+            if (!isset($e)) {
+                return $report;
+            }
+
             if (null !== $report) {
                 $this->getQtiTestService()->clearRelatedResources($report);
             }

--- a/model/tasks/ImportAndCompile.php
+++ b/model/tasks/ImportAndCompile.php
@@ -41,6 +41,7 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 use common_exception_InconsistentData as InconsistentDataException;
 use common_exception_MissingParameter as MissingParameterException;
 use taoQtiTest_models_classes_QtiTestService as QtiTestService;
+use Throwable;
 
 /**
  * Class ImportAndCompile
@@ -121,7 +122,7 @@ class ImportAndCompile extends AbstractTaskAction implements JsonSerializable
             $report->setData(['delivery-uri' => $delivery->getUri()]);
 
             return $report;
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             if (null !== $report) {
                 $this->getQtiTestService()->clearRelatedResources($report);
             }


### PR DESCRIPTION
# [TR-1576](https://oat-sa.atlassian.net/browse/TR-1576)

- fix: catch all errors and exceptions in `ImportAndCompile` task, returning a proper task report
- feat: add an `ImportAndCompile` error logging

https://user-images.githubusercontent.com/2943256/142658528-b753ffa0-6233-416f-b2f1-f7ff9d7a1803.mov

## How to test
1. Set up https://github.com/oat-sa/extension-tao-publishing
2. Set up another TAO instance, running this branch
3. Introduce a fatal error into the `ImportAndCompile` task
4. Publish from the first instance to the updated one