### PR TITLE
TR-3469 date validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=14.0.0",
-        "oat-sa/tao-core": "dev-bugfix/TR-3469/calendar-widget-date-format as 49.4.0",
+        "oat-sa/tao-core": ">=50.0.0",
         "oat-sa/extension-tao-delivery": ">=15.0.0",
         "oat-sa/extension-tao-group": ">=7.0.0",
         "oat-sa/extension-tao-item": ">=11.0.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=14.0.0",
-        "oat-sa/tao-core": ">=49.4.0",
+        "oat-sa/tao-core": "dev-bugfix/TR-3469/calendar-widget-date-format as 49.4.0",
         "oat-sa/extension-tao-delivery": ">=15.0.0",
         "oat-sa/extension-tao-group": ">=7.0.0",
         "oat-sa/extension-tao-item": ">=11.0.0",

--- a/model/validation/DeliveryValidatorFactory.php
+++ b/model/validation/DeliveryValidatorFactory.php
@@ -36,6 +36,11 @@ class DeliveryValidatorFactory extends ConfigurableService
                         'allow_punctuation' => true
                     ]
                 ]
+            ],
+            DeliveryAssemblyService::PROPERTY_START => [
+                [
+                    'DateTime'
+                ]
             ]
         ];
 


### PR DESCRIPTION
# [TR-3469](https://oat-sa.atlassian.net/browse/TR-3469)

## Depends on
https://github.com/oat-sa/tao-core/pull/3408

## Summary 
add `DateTime` validation for `PeriodStart` delivery execution property

## How to test
* install changes
* try to update `PeriodStart` and `PeriodEnd` propery of Delivery by unsupported format or not a date values e.g. `qwerty` or `01 19 2022`
* Exception will be handled and empty value will be provided with corresponding validation message

## TAE
http://test-tr-3469-date-format.playground.kitchen.it.taocloud.org:41401/