### PR TITLE
Ensure theme name from delivery is set in the theme name element in DeliveryForm

### DIFF
--- a/view/form/DeliveryForm.php
+++ b/view/form/DeliveryForm.php
@@ -107,7 +107,18 @@ class DeliveryForm extends SignedFormInstance
             }
         }
 
-        $this->form->getElement($elementUri)->setOptions($options);
+        $themeElement = $this->form->getElement($elementUri);
+
+        $themeElement->setOptions($options);
+
+        // Ensures stored value is selected in the element
+        if ($this->instance !== null) {
+            $themeElement->setValue(
+                $this->instance->getOnePropertyValue(
+                    $this->instance->getProperty(DeliveryThemeDetailsProvider::DELIVERY_THEME_ID_URI)
+                )
+            );
+        }
 
         return true;
     }


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/ADF-1013

## Summary
As per [ADF-841: Remote publishing admin panel is broken](https://oat-sa.atlassian.net/browse/ADF-841), a backport has been performed. Unfortunately, it expects that an API was already present while it was added a bit later by another story, [ADF-711: [GREP] - Handling changes on dependency definition](https://oat-sa.atlassian.net/browse/ADF-711), which was released for December.

## How to test
1. Install TAO with the November LTS release.
2. Install a custom theme, this can be done using a customer extension
[composer.json.zip](https://github.com/oat-sa/extension-tao-delivery-rdf/files/8419656/composer.json.zip)
4. Login to the back office
5. Create a delivery
6. Select a custom theme and save the change
7. Try to open again the page for this delivery instance

## Sandbox environment
http://test-adf-1013.playground.kitchen.it.taocloud.org:40371 ([credentials](http://playground.kitchen.it.taocloud.org/?p=test-adf-1013_delivery.git;a=blob;f=app/admin.txt;h=caff2176c2325ef1004d7c503f9a8778e3e55c8a;hb=HEAD))