### PR TITLE
fix: repair failing test on PHP8.1

### DIFF
--- a/test/unit/model/DataStore/PersistDataServiceTest.php
+++ b/test/unit/model/DataStore/PersistDataServiceTest.php
@@ -28,7 +28,6 @@ use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
 use oat\taoDeliveryRdf\model\DataStore\PersistDataService;
-use taoQtiTest_models_classes_export_TestExport22;
 
 class PersistDataServiceTest extends TestCase
 {
@@ -36,17 +35,20 @@ class PersistDataServiceTest extends TestCase
 
     private FileSystemService $filesystemService;
     private FileHelperService $filesystemHelper;
-    private taoQtiTest_models_classes_export_TestExport22 $exporterHelper;
+    private $exporterHelper;
     private FileSystem $fileSystem;
     private PersistDataService $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
+        $this->exporterHelper = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['export'])
+            ->setMockClassName('tao_models_classes_export_ExportHandler')
+            ->getMock();
 
         $this->filesystemService = $this->createMock(FileSystemService::class);
         $this->filesystemHelper = $this->createMock(FileHelperService::class);
-        $this->exporterHelper = $this->createMock(taoQtiTest_models_classes_export_TestExport22::class);
         $this->fileSystem = $this->createMock(FileSystem::class);
 
         $serviceLocator = $this->getServiceManagerMock([
@@ -66,7 +68,9 @@ class PersistDataServiceTest extends TestCase
      */
     public function testPersist($params): void
     {
-        $this->filesystemHelper->expects($this->once())->method('createTempDir')
+        $this->filesystemHelper
+            ->expects($this->once())
+            ->method('createTempDir')
             ->willReturn('bogusTestDirLocation');
 
         $this->exporterHelper->expects($this->once())->method('export')->willReturn(true);

--- a/test/unit/model/DataStore/PersistDataServiceTest.php
+++ b/test/unit/model/DataStore/PersistDataServiceTest.php
@@ -22,29 +22,23 @@ declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\test\unit\model\DataStore;
 
-use oat\generis\test\TestCase;
+use oat\generis\test\ServiceManagerMockTrait;
+use PHPUnit\Framework\TestCase;
 use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
 use oat\taoDeliveryRdf\model\DataStore\PersistDataService;
-use PHPUnit\Framework\MockObject\MockObject;
 use taoQtiTest_models_classes_export_TestExport22;
 
 class PersistDataServiceTest extends TestCase
 {
-    /** @var FileSystemService|MockObject */
-    private $filesystemService;
+    use ServiceManagerMockTrait;
 
-    /** @var FileHelperService|MockObject */
-    private $filesystemHelper;
-    /** @var MockObject|taoQtiTest_models_classes_export_TestExport22 */
-    private $exporterHelper;
-
-    /** @var FileSystem|MockObject */
-    private $fileSystem;
-
-    /** @var PersistDataService */
-    private $subject;
+    private FileSystemService $filesystemService;
+    private FileHelperService $filesystemHelper;
+    private taoQtiTest_models_classes_export_TestExport22 $exporterHelper;
+    private FileSystem $fileSystem;
+    private PersistDataService $subject;
 
     protected function setUp(): void
     {
@@ -55,7 +49,7 @@ class PersistDataServiceTest extends TestCase
         $this->exporterHelper = $this->createMock(taoQtiTest_models_classes_export_TestExport22::class);
         $this->fileSystem = $this->createMock(FileSystem::class);
 
-        $serviceLocator = $this->getServiceLocatorMock([
+        $serviceLocator = $this->getServiceManagerMock([
             FileSystemService::SERVICE_ID => $this->filesystemService,
             FileHelperService::class => $this->filesystemHelper,
         ]);
@@ -69,7 +63,6 @@ class PersistDataServiceTest extends TestCase
 
     /**
      * @dataProvider provideDataForPersist
-     *
      */
     public function testPersist($params): void
     {

--- a/test/unit/model/DataStore/PersistDataServiceTest.php
+++ b/test/unit/model/DataStore/PersistDataServiceTest.php
@@ -28,6 +28,7 @@ use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
 use oat\taoDeliveryRdf\model\DataStore\PersistDataService;
+use tao_models_classes_export_ExportHandler;
 
 class PersistDataServiceTest extends TestCase
 {
@@ -35,18 +36,14 @@ class PersistDataServiceTest extends TestCase
 
     private FileSystemService $filesystemService;
     private FileHelperService $filesystemHelper;
-    private $exporterHelper;
+    private tao_models_classes_export_ExportHandler $exporterHelper;
     private FileSystem $fileSystem;
     private PersistDataService $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->exporterHelper = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['export'])
-            ->setMockClassName('tao_models_classes_export_ExportHandler')
-            ->getMock();
-
+        $this->exporterHelper = $this->createMock(tao_models_classes_export_ExportHandler::class);
         $this->filesystemService = $this->createMock(FileSystemService::class);
         $this->filesystemHelper = $this->createMock(FileHelperService::class);
         $this->fileSystem = $this->createMock(FileSystem::class);

--- a/test/unit/model/DataStore/ProcessDataServiceTest.php
+++ b/test/unit/model/DataStore/ProcessDataServiceTest.php
@@ -22,24 +22,23 @@ declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\test\unit\model\DataStore;
 
-use oat\generis\test\TestCase;
+use PHPUnit\Framework\TestCase;
 use oat\taoDeliveryRdf\model\DataStore\ProcessDataService;
-use PHPUnit\Framework\MockObject\MockObject;
 use ZipArchive;
 
 class ProcessDataServiceTest extends TestCase
 {
-    /** @var MockObject|ZipArchive */
-    private $zipArchive;
-
-    /** @var ProcessDataService */
-    private $subject;
+    private ZipArchiveForUnitTest $zipArchive;
+    private ProcessDataService $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->zipArchive = $this->createMock(ZipArchive::class);
+        //Need to remove all methods because of PHPUnit 8.5 doesn`t handles return union types used in PHP8
+        $this->zipArchive = $this->getMockBuilder(ZipArchiveForUnitTest::class)
+            ->onlyMethods(['open', 'close', 'addFromString'])
+            ->getMock();
 
         $this->subject = new ProcessDataService(
             [ProcessDataService::OPTION_ZIP_ARCHIVE_SERVICE => $this->zipArchive]
@@ -60,3 +59,25 @@ class ProcessDataServiceTest extends TestCase
         $this->subject->process($zipFile, $metaData);
     }
 }
+
+/**
+ * Class needed to override methods form ZipArchive needed for this test.
+ * Method open() in ZipArchive has UnionType return bool|int and therefore cant be mocked by PHPUnit in version lower
+ * than 9 (currently 8.5 is installed)
+ */
+// @codingStandardsIgnoreStart
+class ZipArchiveForUnitTest extends ZipArchive
+{
+    public function open($filename, $flags = null)
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function addFromString($name, $content, $flags = 8192)
+    {
+    }
+}
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
fix: extend ZipArchive class to remove union type from open() method to mock it in PHPUnit 8.5
fix: remove deprecated code