### PR TITLE
feat: Use feature flag to hide test takers and groups

### DIFF
--- a/views/templates/widgets/excludeTesttaker.tpl
+++ b/views/templates/widgets/excludeTesttaker.tpl
@@ -1,31 +1,33 @@
-<section>
-	<header>
-		<h1><?=__('Test-takers')?></h1>
-	</header>
-	<div>
-	   <div >
-    	   <?php if (get_data('ttassigned') > 0) : ?>
-    	       <?=__('Delivery is assigned to %s test-takers.', get_data('ttassigned')); ?>
-	       <?php else: ?>
-        	   <div class="feedback-info small">
-            	   <span class="icon-info"></span>
-        	       <?=__('Delivery is not assigned to any test-taker.'); ?>
-    	       </div>
-    	   <?php endif; ?>
-	   </div>
-	   <?php if (get_data('ttexcluded') > 0) : ?>
-    	   <div class="feedback-info small">
-    	       <span class="icon-info"></span>
-    	       <?=__('%s test-taker(s) are excluded.', get_data('ttexcluded')); ?>
-    	   </div>
-	   <?php endif; ?>
-	</div>
-	<footer>
-        <?php if (get_data('ttassigned') > 0 || get_data('ttexcluded') > 0) : ?>
-            <button id="exclude-btn" class="btn-info small" type="button" data-delivery="<?= get_data('assemblyUri')?>"><?=__('Excluded test-takers')?></button>
-        <?php endif;?>
-	</footer>
-</section>
+<?php if (get_data('ttdisabled') !== true) : ?>
+	<section>
+		<header>
+			<h1><?=__('Test-takers')?></h1>
+		</header>
+		<div>
+		   <div >
+	    	   <?php if (get_data('ttassigned') > 0) : ?>
+	    	       <?=__('Delivery is assigned to %s test-takers.', get_data('ttassigned')); ?>
+		       <?php else: ?>
+	        	   <div class="feedback-info small">
+	            	   <span class="icon-info"></span>
+	        	       <?=__('Delivery is not assigned to any test-taker.'); ?>
+	    	       </div>
+	    	   <?php endif; ?>
+		   </div>
+		   <?php if (get_data('ttexcluded') > 0) : ?>
+	    	   <div class="feedback-info small">
+	    	       <span class="icon-info"></span>
+	    	       <?=__('%s test-taker(s) are excluded.', get_data('ttexcluded')); ?>
+	    	   </div>
+		   <?php endif; ?>
+		</div>
+		<footer>
+	        <?php if (get_data('ttassigned') > 0 || get_data('ttexcluded') > 0) : ?>
+	            <button id="exclude-btn" class="btn-info small" type="button" data-delivery="<?= get_data('assemblyUri')?>"><?=__('Excluded test-takers')?></button>
+	        <?php endif;?>
+		</footer>
+	</section>
+<?php endif; ?>
 <div id="modal-container" class="tao-scope">
     <div id="testtaker-form" class="modal"></div>	
 </div>


### PR DESCRIPTION
In order to hide groups and test takers we can use feature flags: 
  - FEATURE_FLAG_GROUPS_DISABLED
  - FEATURE_FLAG_TEST_TAKERS_DISABLED

![Screenshot 2023-06-28 at 10 21 36](https://github.com/oat-sa/extension-tao-delivery-rdf/assets/16231681/dfa8b63d-d6f3-4730-ab3f-bfc4c40e138b)

How to test:
1. Define feature flags in environment variables as follows:
```
FEATURE_FLAG_GROUPS_DISABLED=true
FEATURE_FLAG_TEST_TAKERS_DISABLED=true
```
2. Restart phpfpm
3. Check the Delivery tab. Test takers and Groups sections should not be visible