### PR TITLE
Chore: adf-1579/eliminate lodash4 as much as possible

### DIFF
--- a/views/js/controller/Publish/index.js
+++ b/views/js/controller/Publish/index.js
@@ -25,7 +25,7 @@ define([
     'ui/destination/selector',
     'ui/feedback',
     'ui/taskQueue/taskQueue'
-], function ($, _, __, urlHelper, actionManager, resourceProviderFactory, destinationSelectorFactory, feedback, taskQueue) {
+], function ($, __, urlHelper, actionManager, resourceProviderFactory, destinationSelectorFactory, feedback, taskQueue) {
     'use strict';
 
     /**

--- a/views/js/controller/Publish/index.js
+++ b/views/js/controller/Publish/index.js
@@ -18,7 +18,6 @@
  */
 define([
     'jquery',
-    'lodash',
     'i18n',
     'util/url',
     'layout/actions',
@@ -77,7 +76,7 @@ define([
             .on('finished', function (result, button) {
                 if (result.task
                     && result.task.report
-                    && _.isArray(result.task.report.children)
+                    && Array.isArray(result.task.report.children)
                     && result.task.report.children.length
                     && result.task.report.children[0]) {
                     if (result.task.report.children[0].data

--- a/views/js/util/forms/deliveryFormHelper.js
+++ b/views/js/util/forms/deliveryFormHelper.js
@@ -21,7 +21,6 @@
  */
 define([
     'jquery',
-    'lodash',
     'i18n',
     'ui/filter',
     'ui/feedback',
@@ -123,7 +122,7 @@ define([
                 if (result
                     && result.task
                     && result.task.report
-                    && _.isArray(result.task.report.children)
+                    && Array.isArray(result.task.report.children)
                     && result.task.report.children.length
                     && result.task.report.children[0]) {
                     if(result.task.report.children[0].data

--- a/views/js/util/forms/deliveryFormHelper.js
+++ b/views/js/util/forms/deliveryFormHelper.js
@@ -27,7 +27,7 @@ define([
     'layout/actions',
     'ui/taskQueue/taskQueue',
     'ui/taskQueueButton/standardButton'
-], function ($, _, __, filterFactory, feedback, actionManager, taskQueue, taskCreationButtonFactory) {
+], function ($, __, filterFactory, feedback, actionManager, taskQueue, taskCreationButtonFactory) {
     'use strict';
 
     /**


### PR DESCRIPTION
Only left in minified version, guess it will go away after the publishing?

Tested run with local env build. Local tests performed

```
 % ag -l  '_\.' ./taoDeliveryRdf
taoDeliveryRdf/views/js/loader/taoDeliveryRdf.min.js.map
taoDeliveryRdf/views/js/loader/taoDeliveryRdf.min.js
```