### PR TITLE
fix: MetaDataDeliverySyncTask::jsonSerialize return type.

### DIFF
--- a/model/DataStore/MetaDataDeliverySyncTask.php
+++ b/model/DataStore/MetaDataDeliverySyncTask.php
@@ -75,7 +75,7 @@ class MetaDataDeliverySyncTask extends AbstractAction implements JsonSerializabl
         return $report;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return self::class;
     }


### PR DESCRIPTION
## What's Changed
- Fixed return type of MetaDataDeliverySyncTask::jsonSerialize return type.

## TODO 

- [x] Unit tests
- [x] E2E tests

## How to test
- Import Tests from zip file
- Run worker process
- Watch logs:
`tail -f /var/www/html/tao.log`
- No errors should be visible in logs:
`Return type of oat\taoDeliveryRdf\model\DataStore\MetaDataDeliverySyncTask::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`