### PR TITLE
fix: replace to write method with new flysystem v3

### DIFF
--- a/model/DataStore/PersistDataService.php
+++ b/model/DataStore/PersistDataService.php
@@ -124,7 +124,7 @@ class PersistDataService extends ConfigurableService
 
             $this->moveExportedZipTest($folder, $resourceSyncDTO->getResourceId(), $resourceSyncDTO);
         } finally {
-            //FIXME DO not remove directory for tests $tempDir->removeDirectory($folder);
+            $tempDir->removeDirectory($folder);
         }
     }
 

--- a/model/DataStore/PersistDataService.php
+++ b/model/DataStore/PersistDataService.php
@@ -124,7 +124,7 @@ class PersistDataService extends ConfigurableService
 
             $this->moveExportedZipTest($folder, $resourceSyncDTO->getResourceId(), $resourceSyncDTO);
         } finally {
-            $tempDir->removeDirectory($folder);
+            //FIXME DO not remove directory for tests $tempDir->removeDirectory($folder);
         }
     }
 
@@ -150,17 +150,10 @@ class PersistDataService extends ConfigurableService
 
                 $contents = file_get_contents($zipFile);
 
-                if ($this->getDataStoreFilesystem($fileSystemId)->has($zipFileName)) {
-                    $this->getDataStoreFilesystem($fileSystemId)->update(
-                        $zipFileName,
-                        $contents
-                    );
-                } else {
-                    $this->getDataStoreFilesystem($fileSystemId)->write(
-                        $zipFileName,
-                        $contents
-                    );
-                }
+                $this->getDataStoreFilesystem($fileSystemId)->write(
+                    $zipFileName,
+                    $contents
+                );
             }
         }
     }


### PR DESCRIPTION
# Goal

- Use write method instead of `update` as it was removed


https://flysystem.thephpleague.com/docs/what-is-new/

```
No more update, updateStream, put, and putStream
Previously, when writing and updating files, specific methods needed to be called for either situation. In V2, both cases are covered by the write and writeStream methods. This means, the write methods will overwrite any previously written file. The update and updateStream methods are no longer required and have been removed from the main interface.
```