### PR TITLE
Restrict delivery session start/end date options

### DIFF
--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -46,7 +46,6 @@ use oat\taoDeliveryRdf\view\form\WizardForm;
 use oat\taoDeliveryRdf\model\NoTestsException;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoDelivery\model\execution\Monitoring;
-use tao_actions_form_Instance;
 use tao_helpers_form_FormContainer as FormContainer;
 
 /**

--- a/controller/DeliveryMgmt.php
+++ b/controller/DeliveryMgmt.php
@@ -105,15 +105,13 @@ class DeliveryMgmt extends \tao_actions_SaSModule
         $this->defaultData();
         $delivery = $this->getCurrentInstance();
 
-        $taoAsATool = $this->getFeatureFlagChecker()->isEnabled(
-            FeatureFlagCheckerInterface::FEATURE_FLAG_TAO_AS_A_TOOL
-        );
+        $taoAdvanceOnly = $this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_TAO_ADVANCE_ONLY');
 
         $formOptions = [
             FormContainer::CSRF_PROTECTION_OPTION => true,
         ];
 
-        if ($taoAsATool) {
+        if ($taoAdvanceOnly) {
             $formOptions[DeliveryFormFactory::RESTRICTED_PROPERTIES_OPTION] = self::RESTRICT_START_END_DATE;
         }
 

--- a/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
+++ b/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
@@ -28,12 +28,15 @@ use core_kernel_classes_Resource as KernelResource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\DeliveryContainerService;
 use oat\taoDeliveryRdf\model\validation\DeliveryValidatorFactory;
 use oat\taoDeliveryRdf\view\form\DeliveryForm;
+use tao_actions_form_Instance;
 use tao_helpers_form_FormContainer as FormContainer;
 
 class DeliveryFormFactory
 {
+    public const RESTRICTED_PROPERTIES_OPTION = 'restrictedProperties';
     use OntologyAwareTrait;
 
     /** @var DeliveryValidatorFactory */
@@ -43,9 +46,10 @@ class DeliveryFormFactory
     private $dependsOnPropertyValidator;
 
     public function __construct(
-        DeliveryValidatorFactory $validatorFactory,
+        DeliveryValidatorFactory   $validatorFactory,
         DependsOnPropertyValidator $dependsOnPropertyValidator
-    ) {
+    )
+    {
         $this->validatorFactory = $validatorFactory;
         $this->dependsOnPropertyValidator = $dependsOnPropertyValidator;
     }
@@ -57,11 +61,14 @@ class DeliveryFormFactory
             $delivery,
             $additionalOptions + [
                 FormContainer::ADDITIONAL_VALIDATORS => $this->validatorFactory->createMultiple(),
-                FormContainer::ATTRIBUTE_VALIDATORS  => [
+                FormContainer::ATTRIBUTE_VALIDATORS => [
                     'data-depends-on-property' => [
                         $this->dependsOnPropertyValidator
                     ],
                 ],
+                isset($additionalOptions[self::RESTRICTED_PROPERTIES_OPTION])
+                    ? $additionalOptions[self::RESTRICTED_PROPERTIES_OPTION]
+                    : null
             ]
         );
     }

--- a/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
+++ b/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
@@ -36,8 +36,9 @@ use tao_helpers_form_FormContainer as FormContainer;
 
 class DeliveryFormFactory
 {
-    public const RESTRICTED_PROPERTIES_OPTION = 'restrictedProperties';
     use OntologyAwareTrait;
+
+    public const RESTRICTED_PROPERTIES_OPTION = 'restrictedProperties';
 
     /** @var DeliveryValidatorFactory */
     private $validatorFactory;
@@ -46,10 +47,9 @@ class DeliveryFormFactory
     private $dependsOnPropertyValidator;
 
     public function __construct(
-        DeliveryValidatorFactory   $validatorFactory,
+        DeliveryValidatorFactory $validatorFactory,
         DependsOnPropertyValidator $dependsOnPropertyValidator
-    )
-    {
+    ) {
         $this->validatorFactory = $validatorFactory;
         $this->dependsOnPropertyValidator = $dependsOnPropertyValidator;
     }

--- a/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
+++ b/model/Delivery/Presentation/Web/Form/DeliveryFormFactory.php
@@ -28,10 +28,8 @@ use core_kernel_classes_Resource as KernelResource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
-use oat\taoDeliveryRdf\model\DeliveryContainerService;
 use oat\taoDeliveryRdf\model\validation\DeliveryValidatorFactory;
 use oat\taoDeliveryRdf\view\form\DeliveryForm;
-use tao_actions_form_Instance;
 use tao_helpers_form_FormContainer as FormContainer;
 
 class DeliveryFormFactory
@@ -65,10 +63,7 @@ class DeliveryFormFactory
                     'data-depends-on-property' => [
                         $this->dependsOnPropertyValidator
                     ],
-                ],
-                isset($additionalOptions[self::RESTRICTED_PROPERTIES_OPTION])
-                    ? $additionalOptions[self::RESTRICTED_PROPERTIES_OPTION]
-                    : null
+                ]
             ]
         );
     }

--- a/test/unit/model/Delivery/Presentation/Web/Form/DeliveryFormFactoryTest.php
+++ b/test/unit/model/Delivery/Presentation/Web/Form/DeliveryFormFactoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Delivery\Presentation\Web\Form;
+
+use core_kernel_classes_Class as KernelClass;
+use core_kernel_classes_Resource as KernelResource;
+use oat\generis\test\TestCase;
+use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
+use oat\taoDeliveryRdf\model\Delivery\Presentation\Web\Form\DeliveryFormFactory;
+use oat\taoDeliveryRdf\model\validation\DeliveryValidatorFactory;
+use oat\taoDeliveryRdf\view\form\DeliveryForm;
+use tao_helpers_form_FormContainer as FormContainer;
+
+class DeliveryFormFactoryTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testCreateBuildsFormWithValidatorsAndOptions(): void
+    {
+        $this->registerDeliveryFormTestDouble();
+
+        $validators = ['validator'];
+
+        $validatorFactory = $this->createMock(DeliveryValidatorFactory::class);
+        $validatorFactory
+            ->expects($this->once())
+            ->method('createMultiple')
+            ->willReturn($validators);
+
+        $dependsOnPropertyValidator = $this->createMock(DependsOnPropertyValidator::class);
+        $kernelClass = $this->createMock(KernelClass::class);
+        $delivery = $this->createMock(KernelResource::class);
+
+        $factory = new TestableDeliveryFormFactory(
+            $validatorFactory,
+            $dependsOnPropertyValidator,
+            $kernelClass
+        );
+
+        $additionalOptions = ['custom' => 'value'];
+
+        $form = $factory->create($delivery, $additionalOptions);
+
+        $this->assertInstanceOf(DeliveryForm::class, $form);
+        $this->assertSame($additionalOptions['custom'], $form->getOptions()['custom']);
+        $this->assertSame(
+            $validators,
+            $form->getOptions()[FormContainer::ADDITIONAL_VALIDATORS]
+        );
+        $this->assertSame(
+            ['data-depends-on-property' => [$dependsOnPropertyValidator]],
+            $form->getOptions()[FormContainer::ATTRIBUTE_VALIDATORS]
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testCreatePassesRestrictedPropertiesOption(): void
+    {
+        $this->registerDeliveryFormTestDouble();
+
+        $validatorFactory = $this->createMock(DeliveryValidatorFactory::class);
+        $validatorFactory
+            ->expects($this->once())
+            ->method('createMultiple')
+            ->willReturn([]);
+
+        $dependsOnPropertyValidator = $this->createMock(DependsOnPropertyValidator::class);
+        $kernelClass = $this->createMock(KernelClass::class);
+        $delivery = $this->createMock(KernelResource::class);
+
+        $factory = new TestableDeliveryFormFactory(
+            $validatorFactory,
+            $dependsOnPropertyValidator,
+            $kernelClass
+        );
+
+        $restricted = ['property' => ['value']];
+        $additionalOptions = [
+            DeliveryFormFactory::RESTRICTED_PROPERTIES_OPTION => $restricted,
+        ];
+
+        $form = $factory->create($delivery, $additionalOptions);
+
+        $this->assertSame(
+            $restricted,
+            $form->getOptions()[DeliveryFormFactory::RESTRICTED_PROPERTIES_OPTION]
+        );
+    }
+
+    private function registerDeliveryFormTestDouble(): void
+    {
+        if (!class_exists(DeliveryForm::class, false)) {
+            class_alias(TestDeliveryForm::class, DeliveryForm::class);
+        }
+    }
+}
+
+class TestableDeliveryFormFactory extends DeliveryFormFactory
+{
+    /** @var KernelClass */
+    private $class;
+
+    public function __construct(
+        DeliveryValidatorFactory $validatorFactory,
+        DependsOnPropertyValidator $dependsOnPropertyValidator,
+        KernelClass $class
+    ) {
+        parent::__construct($validatorFactory, $dependsOnPropertyValidator);
+        $this->class = $class;
+    }
+
+    public function getClass($uri)
+    {
+        return $this->class;
+    }
+}
+
+class TestDeliveryForm
+{
+    /** @var KernelClass */
+    private $clazz;
+
+    /** @var KernelResource */
+    private $instance;
+
+    /** @var array */
+    private $options;
+
+    public function __construct(KernelClass $clazz, KernelResource $instance = null, $options = [])
+    {
+        $this->clazz = $clazz;
+        $this->instance = $instance;
+        $this->options = $options;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}


### PR DESCRIPTION
## Ticket:
- AUT-4428

## What's Changed
- Restrict Delivery properties: `Start Date`, `End Date` for Authoring used as a tool
- Added unit tests for `DeliveryFormFactory` to validate option wiring (validators, attribute validators, restricted properties).

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [ ] E2E tests
- [ ] Update with packages

## Dependencies PRs
- N/A

## How to test
- From TAO root: `vendor/bin/phpunit path/to/taoDeliveryRdf/test/unit/model/Delivery/Presentation/Web/Form/DeliveryFormFactoryTest.php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forms can optionally restrict start/end date fields when the related feature flag is enabled.
  * Added a public operation to move multiple deliveries with documented access requirements.

* **Security**
  * CSRF protection enabled by default for delivery edit operations.

* **Tests**
  * New unit tests validate form creation, option propagation, and restricted-properties handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->