### PR TITLE
feat: AUT-4526 add RDF usage screens for tests and deliveries

### DIFF
--- a/controller/Usage.php
+++ b/controller/Usage.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\controller;
+
+use common_exception_ResourceNotFound;
+use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
+use GuzzleHttp\Psr7\Response;
+use oat\tao\model\http\formatter\ResponseFormatter;
+use oat\taoDeliveryRdf\model\Usage\DeliveryUsageService;
+use oat\taoDeliveryRdf\model\Usage\TestUsageService;
+use tao_actions_CommonModule;
+use tao_helpers_Uri;
+
+class Usage extends tao_actions_CommonModule
+{
+    use OntologyAwareTrait;
+
+    public function test(): void
+    {
+        $uri = tao_helpers_Uri::decode((string) $this->getRequestParameter('uri'));
+        $resource = $this->getExistingResource($uri);
+
+        $this->setData('mode', 'test');
+        $this->setData('uri', $uri);
+        $this->setData('label', $resource->getLabel());
+        $this->setView('Usage/index.tpl');
+    }
+
+    public function delivery(): void
+    {
+        $uri = tao_helpers_Uri::decode((string) $this->getRequestParameter('uri'));
+        $resource = $this->getExistingResource($uri);
+
+        $this->setData('mode', 'delivery');
+        $this->setData('uri', $uri);
+        $this->setData('label', $resource->getLabel());
+        $this->setView('Usage/index.tpl');
+    }
+
+    public function getTestDeliveriesUsageData(): void
+    {
+        $this->formatResponse($this->getTestUsageService()->getDeliveriesWhereTestUsed($this->getPsrRequest()));
+    }
+
+    public function getDeliverySourceTestData(): void
+    {
+        $this->formatResponse($this->getDeliveryUsageService()->getSourceTestByDelivery($this->getPsrRequest()));
+    }
+
+    private function formatResponse(array $body): void
+    {
+        $responseFormatter = $this->getServiceManager()->getContainer()->get(ResponseFormatter::class);
+
+        $this->setResponse(
+            $responseFormatter
+                ->withJsonHeader()
+                ->withStatusCode(200)
+                ->withBody($body)
+                ->format(new Response())
+        );
+    }
+
+    private function getTestUsageService(): TestUsageService
+    {
+        return $this->getServiceManager()->getContainer()->get(TestUsageService::class);
+    }
+
+    private function getDeliveryUsageService(): DeliveryUsageService
+    {
+        return $this->getServiceManager()->getContainer()->get(DeliveryUsageService::class);
+    }
+
+    private function getExistingResource(string $uri): core_kernel_classes_Resource
+    {
+        $resource = $this->getResource($uri);
+
+        if (!$resource->exists()) {
+            throw new common_exception_ResourceNotFound($uri);
+        }
+
+        return $resource;
+    }
+}

--- a/controller/Usage.php
+++ b/controller/Usage.php
@@ -38,7 +38,7 @@ class Usage extends tao_actions_CommonModule
 
     public function test(): void
     {
-        $uri = tao_helpers_Uri::decode((string) $this->getRequestParameter('uri'));
+        $uri = $this->getRequiredUri();
         $resource = $this->getExistingResource($uri);
 
         $this->setData('mode', 'test');
@@ -49,7 +49,7 @@ class Usage extends tao_actions_CommonModule
 
     public function delivery(): void
     {
-        $uri = tao_helpers_Uri::decode((string) $this->getRequestParameter('uri'));
+        $uri = $this->getRequiredUri();
         $resource = $this->getExistingResource($uri);
 
         $this->setData('mode', 'delivery');
@@ -100,5 +100,16 @@ class Usage extends tao_actions_CommonModule
         }
 
         return $resource;
+    }
+
+    private function getRequiredUri(): string
+    {
+        $decodedUri = trim(tao_helpers_Uri::decode((string) $this->getRequestParameter('uri')));
+
+        if ($decodedUri === '') {
+            throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
+        }
+
+        return $decodedUri;
     }
 }

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -19,19 +19,19 @@
                     />
                 </trees>
                 <actions>
-                    <action id="delivery-class-properties" name="Properties" url="/taoDeliveryRdf/DeliveryMgmt/editClassLabel" group="content" context="class">
+                    <action id="delivery-class-properties" name="Properties" url="/taoDeliveryRdf/DeliveryMgmt/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="delivery-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="delivery-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add" />
                     </action>
-                    <action id="delivery-properties" name="Properties"  url="/taoDeliveryRdf/DeliveryMgmt/editDelivery" group="content" context="instance">
+                    <action id="delivery-properties" name="Properties"  url="/taoDeliveryRdf/DeliveryMgmt/editDelivery" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="delivery-usage" name="Usage" url="/taoDeliveryRdf/Usage/delivery" group="content" context="instance" weight="6">
                         <icon id="icon-filebox"/>
                     </action>
-                    <action id="delivery-class-new" name="New class" url="/taoDeliveryRdf/DeliveryMgmt/addSubClass" context="resource" group="tree" binding="subClass" weight="9">
+                    <action id="delivery-class-new" name="New class" url="/taoDeliveryRdf/DeliveryMgmt/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
                     <action id="delivery-delete" name="Delete" url="/taoDeliveryRdf/DeliveryMgmt/delete" context="resource" group="tree" binding="removeNode" weight="-1">
@@ -61,7 +61,7 @@
         <sections>
             <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                 <actions allowClassActions="true">
-                    <action id="test-publish" name="Publish" url="/taoDeliveryRdf/Publish/index" context="instance" group="tree">
+                    <action id="test-publish" name="Publish" url="/taoDeliveryRdf/Publish/index" context="instance" group="tree" weight="7">
                         <icon id="icon-delivery"/>
                     </action>
                     <action id="test-usage-deliveries" name="Usage" url="/taoDeliveryRdf/Usage/test" context="instance" group="content" weight="6">

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -28,6 +28,9 @@
                     <action id="delivery-properties" name="Properties"  url="/taoDeliveryRdf/DeliveryMgmt/editDelivery" group="content" context="instance">
                         <icon id="icon-edit"/>
                     </action>
+                    <action id="delivery-usage" name="Usage" url="/taoDeliveryRdf/Usage/delivery" group="content" context="instance" weight="6">
+                        <icon id="icon-filebox"/>
+                    </action>
                     <action id="delivery-class-new" name="New class" url="/taoDeliveryRdf/DeliveryMgmt/addSubClass" context="resource" group="tree" binding="subClass" weight="9">
                         <icon id="icon-folder-open"/>
                     </action>
@@ -60,6 +63,9 @@
                 <actions allowClassActions="true">
                     <action id="test-publish" name="Publish" url="/taoDeliveryRdf/Publish/index" context="instance" group="tree">
                         <icon id="icon-delivery"/>
+                    </action>
+                    <action id="test-usage-deliveries" name="Usage" url="/taoDeliveryRdf/Usage/test" context="instance" group="content" weight="6">
+                        <icon id="icon-filebox"/>
                     </action>
                 </actions>
             </section>

--- a/model/Delivery/ServiceProvider/DeliveryServiceProvider.php
+++ b/model/Delivery/ServiceProvider/DeliveryServiceProvider.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2022-2026 (original work) Open Assessment Technologies SA;
  *
  * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace oat\taoDeliveryRdf\model\Delivery\ServiceProvider;
 
+use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\event\EventManager;
 use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
@@ -35,6 +36,9 @@ use oat\taoDeliveryRdf\model\Delivery\Presentation\Web\RequestHandler\DeliverySe
 use oat\taoDeliveryRdf\model\Delivery\Presentation\Web\RequestHandler\JsonDeliveryPatchRequestHandler;
 use oat\taoDeliveryRdf\model\Delivery\Presentation\Web\RequestHandler\UrlEncodedFormDeliveryPatchRequestHandler;
 use oat\taoDeliveryRdf\model\Delivery\Presentation\Web\RequestValidator\DeliverySearchRequestValidator;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\Usage\DeliveryUsageService;
+use oat\taoDeliveryRdf\model\Usage\TestUsageService;
 use oat\taoDeliveryRdf\model\validation\DeliveryValidatorFactory;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator;
@@ -114,6 +118,22 @@ class DeliveryServiceProvider implements ContainerServiceProviderInterface
                 service(DeliveryRepository::class),
                 service(DeliveryFormFactory::class),
                 service(EventManager::class),
+            ]);
+
+        $services
+            ->set(TestUsageService::class, TestUsageService::class)
+            ->public()
+            ->args([
+                service(DeliveryAssemblyService::class),
+                service(Ontology::SERVICE_ID)
+            ]);
+
+        $services
+            ->set(DeliveryUsageService::class, DeliveryUsageService::class)
+            ->public()
+            ->args([
+                service(DeliveryAssemblyService::class),
+                service(Ontology::SERVICE_ID)
             ]);
     }
 }

--- a/model/DeliveryAssemblyService.php
+++ b/model/DeliveryAssemblyService.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2016-2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -115,6 +115,29 @@ class DeliveryAssemblyService extends OntologyClassService
     public function getAllAssemblies()
     {
         return $this->getRootClass()->getInstances(true);
+    }
+
+    /**
+     * Returns assemblies linked to the provided origin test URI.
+     *
+     * @param string $testUri
+     * @param array<string, mixed> $options
+     * @return core_kernel_classes_Resource[]
+     */
+    public function findAssembliesByOrigin(string $testUri, array $options = []): array
+    {
+        $searchOptions = array_merge(
+            [
+                'recursive' => true,
+                'like' => false,
+            ],
+            $options
+        );
+
+        return $this->getRootClass()->searchInstances(
+            [self::PROPERTY_ORIGIN => $testUri],
+            $searchOptions
+        );
     }
 
     /**

--- a/model/Usage/DeliveryUsageService.php
+++ b/model/Usage/DeliveryUsageService.php
@@ -66,7 +66,7 @@ class DeliveryUsageService
                     $rowsData[] = $row;
                 }
             }
-        } catch (\Throwable) {
+        } catch (\Exception) {
             $rowsData = [];
         }
 
@@ -100,7 +100,7 @@ class DeliveryUsageService
         foreach ($classIds as $classId) {
             try {
                 $labels[] = $this->ontology->getClass($classId)->getLabel();
-            } catch (\Throwable) {
+            } catch (\Exception) {
                 continue;
             }
         }
@@ -110,11 +110,17 @@ class DeliveryUsageService
 
     private function getRequiredUri(array $params): string
     {
-        if (empty($params['uri'])) {
+        if (!array_key_exists('uri', $params)) {
             throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
         }
 
-        return tao_helpers_Uri::decode((string) $params['uri']);
+        $decodedUri = trim(tao_helpers_Uri::decode((string) $params['uri']));
+
+        if ($decodedUri === '') {
+            throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
+        }
+
+        return $decodedUri;
     }
 
     private function normalizeSortBy(string $sortBy): string

--- a/model/Usage/DeliveryUsageService.php
+++ b/model/Usage/DeliveryUsageService.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\Usage;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Uri;
+
+class DeliveryUsageService
+{
+    private const DEFAULT_ROWS = 25;
+
+    public function __construct(
+        private DeliveryAssemblyService $deliveryAssemblyService,
+        private Ontology $ontology
+    ) {
+    }
+
+    public function getSourceTestByDelivery(ServerRequestInterface $request): array
+    {
+        $params = $request->getQueryParams();
+        $deliveryUri = $this->getRequiredUri($params);
+        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
+        $rows = $this->getRows($params);
+        $page = $this->getPage($params);
+        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? 'label'));
+        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? 'asc'));
+
+        $rowsData = [];
+        try {
+            $delivery = $this->ontology->getResource($deliveryUri);
+            $origin = $this->deliveryAssemblyService->getOrigin($delivery);
+
+            if ($origin instanceof core_kernel_classes_Resource) {
+                $row = [
+                    'id' => $origin->getUri(),
+                    'sourceTestUri' => $origin->getUri(),
+                    'sourceTestLabel' => $origin->getLabel(),
+                    'label' => $origin->getLabel(),
+                    'location' => $this->resolveClassPath($origin),
+                ];
+
+                if ($filter === '' || mb_strpos(mb_strtolower((string) $row['label']), $filter) !== false) {
+                    $rowsData[] = $row;
+                }
+            }
+        } catch (\Throwable) {
+            $rowsData = [];
+        }
+
+        usort($rowsData, function (array $left, array $right) use ($sortBy, $sortOrder): int {
+            $leftValue = (string) ($left[$sortBy] ?? '');
+            $rightValue = (string) ($right[$sortBy] ?? '');
+            $result = strcmp($leftValue, $rightValue);
+
+            return $sortOrder === 'desc' ? -$result : $result;
+        });
+
+        $totalResults = count($rowsData);
+        $offset = ($page - 1) * $rows;
+        $pagedData = array_slice($rowsData, $offset, $rows);
+
+        return [
+            'totalResults' => $totalResults,
+            'data' => array_values($pagedData),
+            'page' => $page,
+            'total' => $rows > 0 ? (int) ceil($totalResults / $rows) : 0,
+            'totalCount' => $totalResults,
+            'records' => count($pagedData),
+        ];
+    }
+
+    private function resolveClassPath(core_kernel_classes_Resource $resource): string
+    {
+        $classIds = array_reverse($resource->getParentClassesIds());
+        $labels = [];
+
+        foreach ($classIds as $classId) {
+            try {
+                $labels[] = $this->ontology->getClass($classId)->getLabel();
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return implode('/', $labels);
+    }
+
+    private function getRequiredUri(array $params): string
+    {
+        if (empty($params['uri'])) {
+            throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
+        }
+
+        return tao_helpers_Uri::decode((string) $params['uri']);
+    }
+
+    private function normalizeSortBy(string $sortBy): string
+    {
+        return in_array($sortBy, ['label', 'location'], true) ? $sortBy : 'label';
+    }
+
+    private function normalizeSortOrder(string $sortOrder): string
+    {
+        return strtolower($sortOrder) === 'desc' ? 'desc' : 'asc';
+    }
+
+    private function getRows(array $params): int
+    {
+        $rows = (int) ($params['rows'] ?? self::DEFAULT_ROWS);
+
+        return max(1, min($rows, self::DEFAULT_ROWS));
+    }
+
+    private function getPage(array $params): int
+    {
+        return max((int) ($params['page'] ?? 1), 1);
+    }
+}

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\model\Usage;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Uri;
+
+class TestUsageService
+{
+    private const DEFAULT_ROWS = 25;
+
+    public function __construct(
+        private DeliveryAssemblyService $deliveryAssemblyService,
+        private Ontology $ontology
+    ) {
+    }
+
+    public function getDeliveriesWhereTestUsed(ServerRequestInterface $request): array
+    {
+        $params = $request->getQueryParams();
+        $testUri = $this->getRequiredUri($params);
+        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
+        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? 'publicationTime'));
+        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? 'desc'));
+        $rows = $this->getRows($params);
+        $page = $this->getPage($params);
+
+        $rowsData = [];
+        foreach ($this->deliveryAssemblyService->findAssembliesByOrigin($testUri) as $delivery) {
+            if (!$delivery instanceof core_kernel_classes_Resource) {
+                continue;
+            }
+
+            $publicationTime = $this->getPublicationTime($delivery);
+
+            $row = [
+                'id' => $delivery->getUri(),
+                '_id' => $delivery->getUri(),
+                'deliveryId' => $delivery->getUri(),
+                'label' => $delivery->getLabel(),
+                'location' => $this->resolveClassPath($delivery),
+                'classPath' => $this->resolveClassPath($delivery),
+                'publicationTime' => $this->formatPublicationTime($publicationTime),
+                'publicationDate' => $this->formatPublicationTime($publicationTime),
+            ];
+
+            if ($filter !== '' && mb_strpos(mb_strtolower((string) $row['label']), $filter) === false) {
+                continue;
+            }
+
+            $rowsData[] = $row;
+        }
+
+        usort($rowsData, function (array $left, array $right) use ($sortBy, $sortOrder): int {
+            if ($sortBy === 'publicationTime') {
+                $leftValue = $this->toUnixTimestamp((string) ($left[$sortBy] ?? ''));
+                $rightValue = $this->toUnixTimestamp((string) ($right[$sortBy] ?? ''));
+                $result = $leftValue <=> $rightValue;
+            } else {
+                $leftValue = (string) ($left[$sortBy] ?? '');
+                $rightValue = (string) ($right[$sortBy] ?? '');
+                $result = strcmp($leftValue, $rightValue);
+            }
+
+            return $sortOrder === 'desc' ? -$result : $result;
+        });
+
+        $totalResults = count($rowsData);
+        $offset = ($page - 1) * $rows;
+        $pagedData = array_slice($rowsData, $offset, $rows);
+
+        return [
+            'totalResults' => $totalResults,
+            'data' => array_values($pagedData),
+            'page' => $page,
+            'total' => $rows > 0 ? (int) ceil($totalResults / $rows) : 0,
+            'totalCount' => $totalResults,
+            'records' => count($pagedData),
+        ];
+    }
+
+    private function resolveClassPath(core_kernel_classes_Resource $resource): string
+    {
+        $classIds = array_reverse($resource->getParentClassesIds());
+        $labels = [];
+
+        foreach ($classIds as $classId) {
+            try {
+                $labels[] = $this->ontology->getClass($classId)->getLabel();
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return implode('/', $labels);
+    }
+
+    private function getRequiredUri(array $params): string
+    {
+        if (empty($params['uri'])) {
+            throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
+        }
+
+        return tao_helpers_Uri::decode((string) $params['uri']);
+    }
+
+    private function normalizeSortBy(string $sortBy): string
+    {
+        return in_array($sortBy, ['label', 'publicationTime'], true) ? $sortBy : 'publicationTime';
+    }
+
+    private function normalizeSortOrder(string $sortOrder): string
+    {
+        return strtolower($sortOrder) === 'desc' ? 'desc' : 'asc';
+    }
+
+    private function getRows(array $params): int
+    {
+        $rows = (int) ($params['rows'] ?? self::DEFAULT_ROWS);
+
+        return max(1, min($rows, self::DEFAULT_ROWS));
+    }
+
+    private function getPage(array $params): int
+    {
+        return max((int) ($params['page'] ?? 1), 1);
+    }
+
+    private function formatPublicationTime(string $value): string
+    {
+        $timestamp = $this->toUnixTimestamp($value);
+
+        if ($timestamp === 0) {
+            return $value;
+        }
+
+        return date('m/d/Y - H:i', $timestamp);
+    }
+
+    private function toUnixTimestamp(string $value): int
+    {
+        if ($value === '') {
+            return 0;
+        }
+
+        if (is_numeric($value)) {
+            $numeric = (int) $value;
+
+            if (strlen((string) abs($numeric)) >= 13) {
+                return (int) floor($numeric / 1000);
+            }
+
+            return $numeric;
+        }
+
+        $parsed = strtotime($value);
+
+        return $parsed !== false ? $parsed : 0;
+    }
+
+    private function getPublicationTime(core_kernel_classes_Resource $delivery): string
+    {
+        try {
+            return $this->deliveryAssemblyService->getCompilationDate($delivery);
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+}

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -55,16 +55,18 @@ class TestUsageService
             }
 
             $publicationTime = $this->getPublicationTime($delivery);
+            $classPath = $this->resolveClassPath($delivery);
+            $formattedPublicationTime = $this->formatPublicationTime($publicationTime);
 
             $row = [
                 'id' => $delivery->getUri(),
                 '_id' => $delivery->getUri(),
                 'deliveryId' => $delivery->getUri(),
                 'label' => $delivery->getLabel(),
-                'location' => $this->resolveClassPath($delivery),
-                'classPath' => $this->resolveClassPath($delivery),
-                'publicationTime' => $this->formatPublicationTime($publicationTime),
-                'publicationDate' => $this->formatPublicationTime($publicationTime),
+                'location' => $classPath,
+                'classPath' => $classPath,
+                'publicationTime' => $formattedPublicationTime,
+                'publicationDate' => $formattedPublicationTime,
             ];
 
             if ($filter !== '' && mb_strpos(mb_strtolower((string) $row['label']), $filter) === false) {
@@ -120,11 +122,17 @@ class TestUsageService
 
     private function getRequiredUri(array $params): string
     {
-        if (empty($params['uri'])) {
+        if (!array_key_exists('uri', $params)) {
             throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
         }
 
-        return tao_helpers_Uri::decode((string) $params['uri']);
+        $decodedUri = trim(tao_helpers_Uri::decode((string) $params['uri']));
+
+        if ($decodedUri === '') {
+            throw new \common_exception_BadRequest('Missing resource id (uri)', 400);
+        }
+
+        return $decodedUri;
     }
 
     private function normalizeSortBy(string $sortBy): string

--- a/test/unit/model/DeliveryAssemblyServiceTest.php
+++ b/test/unit/model/DeliveryAssemblyServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use PHPUnit\Framework\TestCase;
+
+class DeliveryAssemblyServiceTest extends TestCase
+{
+    public function testFindAssembliesByOriginUsesExpectedSearchFilterAndOptions(): void
+    {
+        $expected = [
+            'http://tao.local/delivery-1' => $this->createMock(core_kernel_classes_Resource::class),
+        ];
+
+        $rootClass = $this->createMock(core_kernel_classes_Class::class);
+        $rootClass
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->with(
+                [DeliveryAssemblyService::PROPERTY_ORIGIN => 'http://tao.local/test-1'],
+                [
+                    'recursive' => true,
+                    'like' => false,
+                ]
+            )
+            ->willReturn($expected);
+
+        $service = $this->getMockBuilder(DeliveryAssemblyService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRootClass'])
+            ->getMock();
+
+        $service
+            ->expects($this->once())
+            ->method('getRootClass')
+            ->willReturn($rootClass);
+
+        $result = $service->findAssembliesByOrigin('http://tao.local/test-1');
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testFindAssembliesByOriginMergesCustomOptions(): void
+    {
+        $rootClass = $this->createMock(core_kernel_classes_Class::class);
+        $rootClass
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->with(
+                [DeliveryAssemblyService::PROPERTY_ORIGIN => 'http://tao.local/test-1'],
+                [
+                    'recursive' => true,
+                    'like' => false,
+                    'limit' => 10,
+                    'offset' => 20,
+                ]
+            )
+            ->willReturn([]);
+
+        $service = $this->getMockBuilder(DeliveryAssemblyService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getRootClass'])
+            ->getMock();
+
+        $service
+            ->expects($this->once())
+            ->method('getRootClass')
+            ->willReturn($rootClass);
+
+        $service->findAssembliesByOrigin('http://tao.local/test-1', [
+            'limit' => 10,
+            'offset' => 20,
+        ]);
+    }
+}

--- a/test/unit/model/Usage/DeliveryUsageServiceTest.php
+++ b/test/unit/model/Usage/DeliveryUsageServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Usage;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\Usage\DeliveryUsageService;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Uri;
+
+class DeliveryUsageServiceTest extends TestCase
+{
+    private const DELIVERY_URI = 'http://tao.local/delivery';
+
+    public function testReturnsSourceTestForDelivery(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $delivery = $this->createResource(self::DELIVERY_URI, 'Delivery');
+        $test = $this->createResource('http://tao.local/test', 'Source Test');
+
+        $ontology->method('getResource')->with(self::DELIVERY_URI)->willReturn($delivery);
+        $deliveryAssemblyService->method('getOrigin')->with($delivery)->willReturn($test);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['uri' => tao_helpers_Uri::encode(self::DELIVERY_URI)]);
+
+        $service = new DeliveryUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getSourceTestByDelivery($request);
+
+        $this->assertSame(1, $result['totalResults']);
+        $this->assertCount(1, $result['data']);
+        $this->assertSame('http://tao.local/test', $result['data'][0]['sourceTestUri']);
+        $this->assertSame('Source Test', $result['data'][0]['sourceTestLabel']);
+    }
+
+    public function testReturnsEmptyWhenOriginCannotBeResolved(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $ontology
+            ->method('getResource')
+            ->willThrowException(new \RuntimeException('Missing delivery'));
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['uri' => tao_helpers_Uri::encode(self::DELIVERY_URI)]);
+
+        $service = new DeliveryUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getSourceTestByDelivery($request);
+
+        $this->assertSame(0, $result['totalResults']);
+        $this->assertSame([], $result['data']);
+    }
+
+    private function createResource(string $uri, string $label): core_kernel_classes_Resource
+    {
+        $resource = $this->createMock(core_kernel_classes_Resource::class);
+        $resource->method('getUri')->willReturn($uri);
+        $resource->method('getLabel')->willReturn($label);
+        $resource->method('getParentClassesIds')->willReturn([]);
+
+        return $resource;
+    }
+}

--- a/test/unit/model/Usage/DeliveryUsageServiceTest.php
+++ b/test/unit/model/Usage/DeliveryUsageServiceTest.php
@@ -76,6 +76,19 @@ class DeliveryUsageServiceTest extends TestCase
         $this->assertSame([], $result['data']);
     }
 
+    public function testThrowsBadRequestWhenUriMissing(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([]);
+
+        $service = new DeliveryUsageService($deliveryAssemblyService, $ontology);
+
+        $this->expectException(\common_exception_BadRequest::class);
+        $service->getSourceTestByDelivery($request);
+    }
+
     private function createResource(string $uri, string $label): core_kernel_classes_Resource
     {
         $resource = $this->createMock(core_kernel_classes_Resource::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -86,6 +86,58 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
     }
 
+    public function testThrowsBadRequestWhenUriMissing(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+
+        $this->expectException(\common_exception_BadRequest::class);
+        $service->getDeliveriesWhereTestUsed($request);
+    }
+
+    public function testUsesFallbackValuesWhenCompilationDateAndClassLookupFail(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $delivery = $this->createDelivery('http://tao.local/delivery-3', 'Delivery 3', ['http://class/missing']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$delivery]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->with($delivery)
+            ->willThrowException(new \RuntimeException('Missing compilation date'));
+
+        $ontology
+            ->method('getClass')
+            ->with('http://class/missing')
+            ->willThrowException(new \RuntimeException('Missing class'));
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame(1, $result['totalResults']);
+        $this->assertCount(1, $result['data']);
+        $this->assertSame('', $result['data'][0]['classPath']);
+        $this->assertSame('', $result['data'][0]['publicationTime']);
+        $this->assertSame('', $result['data'][0]['publicationDate']);
+    }
+
     private function createDelivery(string $uri, string $label, array $parents): core_kernel_classes_Resource
     {
         $delivery = $this->createMock(core_kernel_classes_Resource::class);
@@ -95,5 +147,4 @@ class TestUsageServiceTest extends TestCase
 
         return $delivery;
     }
-
 }

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoDeliveryRdf\test\unit\model\Usage;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\Usage\TestUsageService;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Uri;
+
+class TestUsageServiceTest extends TestCase
+{
+    private const TEST_URI = 'http://tao.local/test';
+
+    public function testReturnsDeliveriesForProvidedTest(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Delivery 1', ['http://class/a']);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Delivery 2', ['http://class/b']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturnMap([
+                [$deliveryOne, '2026-04-09'],
+                [$deliveryTwo, '2026-04-01'],
+            ]);
+
+        $classA = $this->createMock(\core_kernel_classes_Class::class);
+        $classA->method('getLabel')->willReturn('Folder A');
+        $classB = $this->createMock(\core_kernel_classes_Class::class);
+        $classB->method('getLabel')->willReturn('Folder B');
+
+        $ontology->method('getClass')->willReturnMap([
+            ['http://class/a', $classA],
+            ['http://class/b', $classB],
+        ]);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'sortby' => 'label',
+            'sortorder' => 'asc',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame(2, $result['totalResults']);
+        $this->assertCount(2, $result['data']);
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][0]['deliveryId']);
+        $this->assertSame('Delivery 1', $result['data'][0]['label']);
+        $this->assertSame('Folder A', $result['data'][0]['classPath']);
+        $this->assertSame('04/09/2026 - 00:00', $result['data'][0]['publicationTime']);
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
+    }
+
+    private function createDelivery(string $uri, string $label, array $parents): core_kernel_classes_Resource
+    {
+        $delivery = $this->createMock(core_kernel_classes_Resource::class);
+        $delivery->method('getUri')->willReturn($uri);
+        $delivery->method('getLabel')->willReturn($label);
+        $delivery->method('getParentClassesIds')->willReturn($parents);
+
+        return $delivery;
+    }
+
+}

--- a/views/css/usage.css
+++ b/views/css/usage.css
@@ -1,0 +1,27 @@
+.usage-data-container {
+    width: 100%;
+}
+
+.usage-data-container .usage-grid {
+    display: block;
+    width: 100%;
+}
+
+.usage-data-container .usage-grid .datatable-wrapper {
+    display: block;
+}
+
+.usage-data-container .usage-grid table.datatable .actions {
+    white-space: nowrap;
+}
+
+.usage-data-container .usage-grid table.datatable .actions [class^="btn-"] {
+    border: 1px solid #222;
+    background-color: transparent;
+    color: #222;
+    text-shadow: none;
+}
+
+.usage-data-container .results-list .grid-row.pagination {
+    width: 100%;
+}

--- a/views/js/controller/Usage/index.js
+++ b/views/js/controller/Usage/index.js
@@ -30,18 +30,24 @@ define([
 
     function getNumRows() {
         const $upperElem = $('.content-container h2');
-        const topSpace = $upperElem.offset().top
-            + $upperElem.height()
-            + parseInt($upperElem.css('margin-bottom'), 10)
+        const topOffset = $upperElem.length > 0 && $upperElem.offset() ? $upperElem.offset().top : 0;
+        const upperHeight = $upperElem.length > 0 ? ($upperElem.height() || 0) : 0;
+        const marginBottom = $upperElem.length > 0 ? (parseInt($upperElem.css('margin-bottom'), 10) || 0) : 0;
+        const footerHeight = $('footer.dark-bar').outerHeight() || 0;
+        const topSpace = topOffset
+            + upperHeight
+            + marginBottom
             + lineHeight
             + searchPagination;
-        const availableHeight = $(window).height() - topSpace - $('footer.dark-bar').outerHeight();
+        const availableHeight = $(window).height() - topSpace - footerHeight;
 
         if (!window.MSInputMethodContext && !document.documentMode && !window.StyleMedia) {
             return 25;
         }
 
-        return Math.min(Math.floor(availableHeight / lineHeight), 25);
+        const computedRows = availableHeight > 0 ? Math.floor(availableHeight / lineHeight) : 1;
+
+        return Math.max(1, Math.min(computedRows, 25));
     }
 
     function getColumns(mode) {
@@ -85,6 +91,11 @@ define([
             const $grid = $('.usage-grid');
             const mode = $grid.data('mode');
             const uri = $grid.data('uri');
+
+            if (typeof uri !== 'string' || uri.trim() === '' || (mode !== 'delivery' && mode !== 'test')) {
+                return;
+            }
+
             const dataUrl = mode === 'delivery'
                 ? url.route('getDeliverySourceTestData', 'Usage', 'taoDeliveryRdf', { uri: uri })
                 : url.route('getTestDeliveriesUsageData', 'Usage', 'taoDeliveryRdf', { uri: uri });
@@ -113,7 +124,15 @@ define([
                                 uri: targetUri
                             };
 
-                        window.open(url.build(urlInfo.path, pathParams), '_blank');
+                        const openedWindow = window.open(
+                            url.build(urlInfo.path, pathParams),
+                            '_blank',
+                            'noopener,noreferrer'
+                        );
+
+                        if (openedWindow) {
+                            openedWindow.opener = null;
+                        }
                     }
                 }
             ];

--- a/views/js/controller/Usage/index.js
+++ b/views/js/controller/Usage/index.js
@@ -1,0 +1,138 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+define([
+    'jquery',
+    'i18n',
+    'util/url',
+    'ui/datatable',
+    'layout/actions/binder'
+], function ($, __, url) {
+    'use strict';
+
+    const lineHeight = 30;
+    const searchPagination = 70;
+
+    function getNumRows() {
+        const $upperElem = $('.content-container h2');
+        const topSpace = $upperElem.offset().top
+            + $upperElem.height()
+            + parseInt($upperElem.css('margin-bottom'), 10)
+            + lineHeight
+            + searchPagination;
+        const availableHeight = $(window).height() - topSpace - $('footer.dark-bar').outerHeight();
+
+        if (!window.MSInputMethodContext && !document.documentMode && !window.StyleMedia) {
+            return 25;
+        }
+
+        return Math.min(Math.floor(availableHeight / lineHeight), 25);
+    }
+
+    function getColumns(mode) {
+        if (mode === 'delivery') {
+            return [
+                {
+                    id: 'label',
+                    label: __('Label'),
+                    sortable: true
+                },
+                {
+                    id: 'location',
+                    label: __('Location'),
+                    sortable: false
+                }
+            ];
+        }
+
+        return [
+            {
+                id: 'label',
+                label: __('Label'),
+                sortable: true
+            },
+            {
+                id: 'location',
+                label: __('Location'),
+                sortable: false
+            },
+            {
+                id: 'publicationTime',
+                label: __('Last modified on'),
+                sortable: true
+            }
+        ];
+    }
+
+    return {
+        start: function start() {
+            const urlInfo = url.parse(window.location);
+            const $grid = $('.usage-grid');
+            const mode = $grid.data('mode');
+            const uri = $grid.data('uri');
+            const dataUrl = mode === 'delivery'
+                ? url.route('getDeliverySourceTestData', 'Usage', 'taoDeliveryRdf', { uri: uri })
+                : url.route('getTestDeliveriesUsageData', 'Usage', 'taoDeliveryRdf', { uri: uri });
+
+            const actions = [
+                {
+                    id: 'link-action',
+                    title: __('View'),
+                    label: __('View'),
+                    disabled: function disabled() {
+                        return !this.id;
+                    },
+                    action: function action(targetUri) {
+
+                        const pathParams = mode === 'delivery'
+                            ? {
+                                ext: 'taoTests',
+                                section: 'manage_tests',
+                                structure: 'tests',
+                                uri: targetUri
+                            }
+                            : {
+                                ext: 'taoDeliveryRdf',
+                                section: 'manage_delivery_assembly',
+                                structure: 'delivery',
+                                uri: targetUri
+                            };
+
+                        window.open(url.build(urlInfo.path, pathParams), '_blank');
+                    }
+                }
+            ];
+
+            $grid.datatable({
+                url: dataUrl,
+                filter: true,
+                labels: {
+                    filter: mode === 'delivery' ? __('Search Tests') : __('Search Deliveries'),
+                    title: mode === 'delivery' ? __('Search Tests') : __('Search Deliveries')
+                },
+                model: getColumns(mode),
+                paginationStrategyTop: 'none',
+                paginationStrategyBottom: 'simple',
+                rows: getNumRows(),
+                sortby: mode === 'delivery' ? 'label' : 'publicationTime',
+                sortorder: mode === 'delivery' ? 'asc' : 'desc',
+                actions: actions
+            });
+        }
+    };
+});

--- a/views/js/controller/routes.js
+++ b/views/js/controller/routes.js
@@ -11,9 +11,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2014-2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  *
  */
@@ -33,6 +33,12 @@ define(function(){
         'Publish': {
             'actions' : {
                 'index' : 'controller/Publish/index'
+            }
+        },
+        'Usage': {
+            'actions': {
+                'test': 'controller/Usage/index',
+                'delivery': 'controller/Usage/index'
             }
         }
     };

--- a/views/templates/Usage/index.tpl
+++ b/views/templates/Usage/index.tpl
@@ -9,7 +9,7 @@ $title = $mode === 'delivery' ? __('Delivery source test usage') : __('Test deli
 <link rel="stylesheet" type="text/css" href="<?= Template::css('usage.css') ?>"/>
 
 <div class="usage-data-container">
-    <h2><?= $title ?></h2>
+    <h2><?= _dh($title) ?></h2>
     <div class="data-container-wrapper flex-container-full">
         <div class="grid-row">
             <div class="col-12">

--- a/views/templates/Usage/index.tpl
+++ b/views/templates/Usage/index.tpl
@@ -1,0 +1,29 @@
+<?php
+
+use oat\tao\helpers\Template;
+
+$mode = get_data('mode');
+$title = $mode === 'delivery' ? __('Delivery source test usage') : __('Test delivery usage');
+?>
+
+<link rel="stylesheet" type="text/css" href="<?= Template::css('usage.css') ?>"/>
+
+<div class="usage-data-container">
+    <h2><?= $title ?></h2>
+    <div class="data-container-wrapper flex-container-full">
+        <div class="grid-row">
+            <div class="col-12">
+                <div
+                    class="usage-grid"
+                    data-mode="<?= _dh((string) get_data('mode')) ?>"
+                    data-uri="<?= _dh((string) get_data('uri')) ?>"
+                    data-label="<?= _dh((string) get_data('label')) ?>"
+                ></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+Template::inc('footer.tpl', 'tao');
+?>


### PR DESCRIPTION
sc## Summary
- add RDF-based Usage flow in `taoDeliveryRdf` with two dedicated services: `TestUsageService` (test -> deliveries) and `DeliveryUsageService` (delivery -> source test)
- add `Usage` controller endpoints and a shared UI screen for both test and delivery contexts, aligned with TAO Usage patterns
- wire services into existing `DeliveryServiceProvider` and expose consistent `Usage` actions in `structures.xml` for tests and deliveries
- fix request URI handling to decode TAO-encoded `uri` values (`tao_helpers_Uri::decode`) in both usage services and controller actions
- validate resource existence in `Usage` controller before rendering screen (`common_exception_ResourceNotFound` for missing resources)
- align datatable rendering and payload shape with Item Usage (`label`, `location`, `publicationTime`, dynamic rows, view action)
- fix datatable `View` action to pass target `uri` argument so navigation opens selected resource instead of root class
- format `publicationTime
` values as readable dates and sort by parsed timestamp

https://github.com/user-attachments/assets/0789bde6-a92a-47aa-9b0c-b499899e887b

Tickets:
https://oat-sa.atlassian.net/browse/AUT-4528
https://oat-sa.atlassian.net/browse/AUT-4527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Usage pages for tests and deliveries with data tables (filtering, sorting, pagination) and a "View" action.
  * Added "Usage" actions in test and delivery management for quick access to usage details.
  * Added server-backed endpoints powering the tables and integrated client routes, template, and styles.

* **Tests**
  * Added unit tests covering usage data retrieval, filtering, sorting, pagination, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->