### PR TITLE
fix: AUT-4526 enable test usage sorting by location

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -28,7 +28,7 @@
                     <action id="delivery-properties" name="Properties"  url="/taoDeliveryRdf/DeliveryMgmt/editDelivery" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="delivery-usage" name="Usage" url="/taoDeliveryRdf/Usage/delivery" group="content" context="instance" weight="6">
+                    <action id="delivery-usage" name="Usage" url="/taoDeliveryRdf/Usage/delivery" group="content" context="instance" weight="7">
                         <icon id="icon-filebox"/>
                     </action>
                     <action id="delivery-class-new" name="New class" url="/taoDeliveryRdf/DeliveryMgmt/addSubClass" context="resource" group="tree" binding="subClass" weight="10">

--- a/model/Usage/DeliveryUsageService.php
+++ b/model/Usage/DeliveryUsageService.php
@@ -45,8 +45,8 @@ class DeliveryUsageService
         $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
         $rows = $this->getRows($params);
         $page = $this->getPage($params);
-        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? 'label'));
-        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? 'asc'));
+        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? $params['sortBy'] ?? 'label'));
+        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? $params['sortOrder'] ?? 'asc'));
 
         $rowsData = [];
         try {
@@ -125,12 +125,24 @@ class DeliveryUsageService
 
     private function normalizeSortBy(string $sortBy): string
     {
-        return in_array($sortBy, ['label', 'location'], true) ? $sortBy : 'label';
+        $normalized = strtolower(trim($sortBy));
+
+        return in_array($normalized, ['label', 'location'], true) ? $normalized : 'label';
     }
 
     private function normalizeSortOrder(string $sortOrder): string
     {
-        return strtolower($sortOrder) === 'desc' ? 'desc' : 'asc';
+        $normalized = strtolower(trim($sortOrder));
+
+        if (in_array($normalized, ['desc', '-1', 'descending'], true)) {
+            return 'desc';
+        }
+
+        if (in_array($normalized, ['asc', '1', 'ascending'], true)) {
+            return 'asc';
+        }
+
+        return 'asc';
     }
 
     private function getRows(array $params): int

--- a/model/Usage/DeliveryUsageService.php
+++ b/model/Usage/DeliveryUsageService.php
@@ -42,7 +42,7 @@ class DeliveryUsageService
     {
         $params = $request->getQueryParams();
         $deliveryUri = $this->getRequiredUri($params);
-        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
+        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? $params['filterQuery'] ?? '')));
         $rows = $this->getRows($params);
         $page = $this->getPage($params);
         $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? $params['sortBy'] ?? 'label'));

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -43,8 +43,8 @@ class TestUsageService
         $params = $request->getQueryParams();
         $testUri = $this->getRequiredUri($params);
         $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
-        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? 'publicationTime'));
-        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? 'desc'));
+        $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? $params['sortBy'] ?? 'publicationTime'));
+        $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? $params['sortOrder'] ?? 'desc'));
         $rows = $this->getRows($params);
         $page = $this->getPage($params);
 
@@ -55,6 +55,7 @@ class TestUsageService
             }
 
             $publicationTime = $this->getPublicationTime($delivery);
+            $publicationTimestamp = $this->toUnixTimestamp($publicationTime);
             $classPath = $this->resolveClassPath($delivery);
             $formattedPublicationTime = $this->formatPublicationTime($publicationTime);
 
@@ -67,6 +68,7 @@ class TestUsageService
                 'classPath' => $classPath,
                 'publicationTime' => $formattedPublicationTime,
                 'publicationDate' => $formattedPublicationTime,
+                'publicationTimestamp' => $publicationTimestamp,
             ];
 
             if ($filter !== '' && mb_strpos(mb_strtolower((string) $row['label']), $filter) === false) {
@@ -78,8 +80,8 @@ class TestUsageService
 
         usort($rowsData, function (array $left, array $right) use ($sortBy, $sortOrder): int {
             if ($sortBy === 'publicationTime') {
-                $leftValue = $this->toUnixTimestamp((string) ($left[$sortBy] ?? ''));
-                $rightValue = $this->toUnixTimestamp((string) ($right[$sortBy] ?? ''));
+                $leftValue = (int) ($left['publicationTimestamp'] ?? $this->toUnixTimestamp((string) ($left[$sortBy] ?? '')));
+                $rightValue = (int) ($right['publicationTimestamp'] ?? $this->toUnixTimestamp((string) ($right[$sortBy] ?? '')));
                 $result = $leftValue <=> $rightValue;
             } else {
                 $leftValue = (string) ($left[$sortBy] ?? '');
@@ -137,14 +139,32 @@ class TestUsageService
 
     private function normalizeSortBy(string $sortBy): string
     {
-        return in_array($sortBy, ['label', 'location', 'publicationTime'], true)
-            ? $sortBy
-            : 'publicationTime';
+        $normalized = strtolower(trim($sortBy));
+        $supportedSortBy = [
+            'label' => 'label',
+            'location' => 'location',
+            'publicationtime' => 'publicationTime',
+            'publicationdate' => 'publicationTime',
+            'publication_date' => 'publicationTime',
+            'publicationtimestamp' => 'publicationTime',
+        ];
+
+        return $supportedSortBy[$normalized] ?? 'publicationTime';
     }
 
     private function normalizeSortOrder(string $sortOrder): string
     {
-        return strtolower($sortOrder) === 'desc' ? 'desc' : 'asc';
+        $normalized = strtolower(trim($sortOrder));
+
+        if (in_array($normalized, ['desc', '-1', 'descending'], true)) {
+            return 'desc';
+        }
+
+        if (in_array($normalized, ['asc', '1', 'ascending'], true)) {
+            return 'asc';
+        }
+
+        return 'desc';
     }
 
     private function getRows(array $params): int

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -137,7 +137,9 @@ class TestUsageService
 
     private function normalizeSortBy(string $sortBy): string
     {
-        return in_array($sortBy, ['label', 'publicationTime'], true) ? $sortBy : 'publicationTime';
+        return in_array($sortBy, ['label', 'location', 'publicationTime'], true)
+            ? $sortBy
+            : 'publicationTime';
     }
 
     private function normalizeSortOrder(string $sortOrder): string

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -80,8 +80,10 @@ class TestUsageService
 
         usort($rowsData, function (array $left, array $right) use ($sortBy, $sortOrder): int {
             if ($sortBy === 'publicationTime') {
-                $leftValue = (int) ($left['publicationTimestamp'] ?? $this->toUnixTimestamp((string) ($left[$sortBy] ?? '')));
-                $rightValue = (int) ($right['publicationTimestamp'] ?? $this->toUnixTimestamp((string) ($right[$sortBy] ?? '')));
+                $leftFallbackValue = $this->toUnixTimestamp((string) ($left[$sortBy] ?? ''));
+                $rightFallbackValue = $this->toUnixTimestamp((string) ($right[$sortBy] ?? ''));
+                $leftValue = (int) ($left['publicationTimestamp'] ?? $leftFallbackValue);
+                $rightValue = (int) ($right['publicationTimestamp'] ?? $rightFallbackValue);
                 $result = $leftValue <=> $rightValue;
             } else {
                 $leftValue = (string) ($left[$sortBy] ?? '');

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -42,7 +42,7 @@ class TestUsageService
     {
         $params = $request->getQueryParams();
         $testUri = $this->getRequiredUri($params);
-        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? '')));
+        $filter = mb_strtolower(trim((string) ($params['filterquery'] ?? $params['filterQuery'] ?? '')));
         $sortBy = $this->normalizeSortBy((string) ($params['sortby'] ?? $params['sortBy'] ?? 'publicationTime'));
         $sortOrder = $this->normalizeSortOrder((string) ($params['sortorder'] ?? $params['sortOrder'] ?? 'desc'));
         $rows = $this->getRows($params);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -228,8 +228,8 @@ class TestUsageServiceTest extends TestCase
         $deliveryAssemblyService
             ->method('getCompilationDate')
             ->willReturnMap([
-                [$deliveryOne, '2026-04-10 15:01:00'],
-                [$deliveryTwo, '2026-04-09 15:01:00'],
+                [$deliveryOne, '1775833260000'],
+                [$deliveryTwo, '1775746860000'],
             ]);
 
         $classA = $this->createMock(\core_kernel_classes_Class::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -129,6 +129,83 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-1', $result['data'][1]['deliveryId']);
     }
 
+    public function testSupportsCamelCaseSortParamsAndNumericSortOrder(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'A Delivery', ['http://class/a']);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Z Delivery', ['http://class/a']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturn('2026-04-09');
+
+        $classA = $this->createMock(\core_kernel_classes_Class::class);
+        $classA->method('getLabel')->willReturn('Folder A');
+        $ontology->method('getClass')->willReturn($classA);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'sortBy' => 'label',
+            'sortOrder' => '-1',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][0]['deliveryId']);
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][1]['deliveryId']);
+    }
+
+    public function testSortsDeliveriesByPublicationTimeUsingRawTimestamp(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Delivery 1', ['http://class/a']);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Delivery 2', ['http://class/a']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturnMap([
+                [$deliveryOne, '2026-04-10 15:01:00'],
+                [$deliveryTwo, '2026-04-09 15:01:00'],
+            ]);
+
+        $classA = $this->createMock(\core_kernel_classes_Class::class);
+        $classA->method('getLabel')->willReturn('Folder A');
+        $ontology->method('getClass')->willReturn($classA);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'sortby' => 'publicationTime',
+            'sortorder' => 'desc',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][0]['deliveryId']);
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
+    }
+
     public function testThrowsBadRequestWhenUriMissing(): void
     {
         $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -86,6 +86,49 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
     }
 
+    public function testSortsDeliveriesByLocation(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Delivery 1', ['http://class/z']);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Delivery 2', ['http://class/a']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturn('2026-04-09');
+
+        $classZ = $this->createMock(\core_kernel_classes_Class::class);
+        $classZ->method('getLabel')->willReturn('Zulu Folder');
+        $classA = $this->createMock(\core_kernel_classes_Class::class);
+        $classA->method('getLabel')->willReturn('Alpha Folder');
+
+        $ontology->method('getClass')->willReturnMap([
+            ['http://class/z', $classZ],
+            ['http://class/a', $classA],
+        ]);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'sortby' => 'location',
+            'sortorder' => 'asc',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][0]['deliveryId']);
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][1]['deliveryId']);
+    }
+
     public function testThrowsBadRequestWhenUriMissing(): void
     {
         $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -129,6 +129,52 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-1', $result['data'][1]['deliveryId']);
     }
 
+    public function testFallsBackToPublicationTimeSortingWhenSortByIsUnsupported(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Delivery 1', ['http://class/z']);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Delivery 2', ['http://class/a']);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturnMap([
+                [$deliveryOne, '2026-04-09 00:00:00'],
+                [$deliveryTwo, '2026-04-10 00:00:00'],
+            ]);
+
+        $classZ = $this->createMock(\core_kernel_classes_Class::class);
+        $classZ->method('getLabel')->willReturn('Zulu Folder');
+        $classA = $this->createMock(\core_kernel_classes_Class::class);
+        $classA->method('getLabel')->willReturn('Alpha Folder');
+
+        $ontology->method('getClass')->willReturnMap([
+            ['http://class/z', $classZ],
+            ['http://class/a', $classA],
+        ]);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'sortby' => 'invalidField',
+            'sortorder' => 'desc',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][0]['deliveryId']);
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][1]['deliveryId']);
+    }
+
     public function testSupportsCamelCaseSortParamsAndNumericSortOrder(): void
     {
         $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);

--- a/views/js/controller/Usage/index.js
+++ b/views/js/controller/Usage/index.js
@@ -75,7 +75,7 @@ define([
             {
                 id: 'location',
                 label: __('Location'),
-                sortable: false
+                sortable: true
             },
             {
                 id: 'publicationTime',


### PR DESCRIPTION
## Summary
- enable sorting by `Location` in Test Usage tab datatable so behavior matches Item Usage expectations
- extend `TestUsageService` sorting whitelist with `location` and preserve existing default sort by `publicationTime desc`
- add unit coverage proving ascending sort by location for test usage deliveries

## Validation
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoDeliveryRdf/test/unit/model/Usage/DeliveryUsageServiceTest.php`
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoDeliveryRdf/test/unit/model/Usage/TestUsageServiceTest.php`
- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox taoDeliveryRdf/test/unit/model/DeliveryAssemblyServiceTest.php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Location is now a sortable column in delivery lists; UI supports sorting by location.
  * Sorting queries accept alternative parameter spellings and additional tokens for ascending/descending.

* **Bug Fixes**
  * Listings include a normalized numeric publication timestamp and more deterministic sorting across mixed-type publication time values.

* **Tests**
  * Added a unit test covering sorting by location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->