### PR TITLE
Fix/aut 4577/aut 4578/aut 4579

### DIFF
--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -1,8 +1,7 @@
 msgid ""
 msgstr ""
-
-"Project-Id-Version: TAO 3.3.0-sprint107\n"
-"PO-Revision-Date: 2020-07-17T08:37:23\n"
+"Project-Id-Version: TAO 2026.06\n"
+"PO-Revision-Date: 2026-05-15T11:46:08\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"
@@ -92,6 +91,9 @@ msgstr ""
 msgid "Delivery saved"
 msgstr ""
 
+msgid "Delivery source test usage"
+msgstr ""
+
 msgid "Delivery with label \"%s\" not found"
 msgstr ""
 
@@ -119,7 +121,13 @@ msgstr ""
 msgid "Importing %1$s files into \'%2$s\'"
 msgstr ""
 
+msgid "Label"
+msgstr ""
+
 msgid "Last updated on:"
+msgstr ""
+
+msgid "Location"
 msgstr ""
 
 #, tao-public
@@ -170,6 +178,9 @@ msgstr ""
 msgid "Publish the test"
 msgstr ""
 
+msgid "Published on"
+msgstr ""
+
 msgid "Published on:"
 msgstr ""
 
@@ -177,6 +188,12 @@ msgid "Publishing of <b>%s</b>"
 msgstr ""
 
 msgid "Save"
+msgstr ""
+
+msgid "Search Deliveries"
+msgstr ""
+
+msgid "Search Tests"
 msgstr ""
 
 msgid "Select the test"
@@ -192,6 +209,9 @@ msgid "TAO Guest"
 msgstr ""
 
 msgid "TAO Guest Access"
+msgstr ""
+
+msgid "Test delivery usage"
 msgstr ""
 
 msgid "Test publishing failed because \"%s\" is empty."
@@ -225,8 +245,15 @@ msgstr ""
 msgid "unlimited"
 msgstr ""
 
+#, tao-public
+msgid "Usage"
+msgstr ""
+
 msgid "Usage: %s ASSEMBLY_FILE [ASSEMBLY_FILE_2] [ASSEMBLY_FILE_3] ..."
 msgstr ""
 
 msgid "Usage: %s DELIVERY_CLASS_URI OUTPUT_DIRECTORY"
+msgstr ""
+
+msgid "View"
 msgstr ""

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -26,6 +26,7 @@ use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Date;
 use tao_helpers_Uri;
 
 class TestUsageService
@@ -188,8 +189,8 @@ class TestUsageService
         if ($timestamp === 0) {
             return $value;
         }
-
-        return date('m/d/Y - H:i', $timestamp);
+        
+        return tao_helpers_Date::displayeDate($value);
     }
 
     private function toUnixTimestamp(string $value): int

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -189,7 +189,7 @@ class TestUsageService
         if ($timestamp === 0) {
             return $value;
         }
-        
+
         return tao_helpers_Date::displayeDate($value);
     }
 

--- a/model/Usage/TestUsageService.php
+++ b/model/Usage/TestUsageService.php
@@ -190,7 +190,7 @@ class TestUsageService
             return $value;
         }
 
-        return tao_helpers_Date::displayeDate($value);
+        return tao_helpers_Date::displayeDate($timestamp);
     }
 
     private function toUnixTimestamp(string $value): int

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -317,6 +317,38 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-2', $result['data'][0]['deliveryId']);
     }
 
+    public function testFiltersReturnsNoMatch(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Alpha Delivery', []);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Beta Delivery', []);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturn('2026-04-09');
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'filterquery' => 'no-match',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame(0, $result['totalResults']);
+        $this->assertSame([], $result['data']);
+    }
+
     public function testThrowsBadRequestWhenUriMissing(): void
     {
         $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -252,6 +252,71 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
     }
 
+    public function testFiltersDeliveriesByLabel(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Alpha Delivery', []);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Beta Delivery', []);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturn('2026-04-09');
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'filterquery' => 'alpha',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame(1, $result['totalResults']);
+        $this->assertCount(1, $result['data']);
+        $this->assertSame('http://tao.local/delivery-1', $result['data'][0]['deliveryId']);
+    }
+
+    public function testSupportsCamelCaseFilterQueryParam(): void
+    {
+        $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);
+        $ontology = $this->createMock(Ontology::class);
+
+        $deliveryOne = $this->createDelivery('http://tao.local/delivery-1', 'Alpha Delivery', []);
+        $deliveryTwo = $this->createDelivery('http://tao.local/delivery-2', 'Beta Delivery', []);
+
+        $deliveryAssemblyService
+            ->method('findAssembliesByOrigin')
+            ->with(self::TEST_URI)
+            ->willReturn([$deliveryOne, $deliveryTwo]);
+
+        $deliveryAssemblyService
+            ->method('getCompilationDate')
+            ->willReturn('2026-04-09');
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'uri' => tao_helpers_Uri::encode(self::TEST_URI),
+            'rows' => 25,
+            'page' => 1,
+            'filterQuery' => 'beta',
+        ]);
+
+        $service = new TestUsageService($deliveryAssemblyService, $ontology);
+        $result = $service->getDeliveriesWhereTestUsed($request);
+
+        $this->assertSame(1, $result['totalResults']);
+        $this->assertSame('http://tao.local/delivery-2', $result['data'][0]['deliveryId']);
+    }
+
     public function testThrowsBadRequestWhenUriMissing(): void
     {
         $deliveryAssemblyService = $this->createMock(DeliveryAssemblyService::class);

--- a/test/unit/model/Usage/TestUsageServiceTest.php
+++ b/test/unit/model/Usage/TestUsageServiceTest.php
@@ -28,6 +28,7 @@ use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoDeliveryRdf\model\Usage\TestUsageService;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use tao_helpers_Date;
 use tao_helpers_Uri;
 
 class TestUsageServiceTest extends TestCase
@@ -82,7 +83,10 @@ class TestUsageServiceTest extends TestCase
         $this->assertSame('http://tao.local/delivery-1', $result['data'][0]['deliveryId']);
         $this->assertSame('Delivery 1', $result['data'][0]['label']);
         $this->assertSame('Folder A', $result['data'][0]['classPath']);
-        $this->assertSame('04/09/2026 - 00:00', $result['data'][0]['publicationTime']);
+        $this->assertSame(
+            tao_helpers_Date::displayeDate(strtotime('2026-04-09')),
+            $result['data'][0]['publicationTime']
+        );
         $this->assertSame('http://tao.local/delivery-2', $result['data'][1]['deliveryId']);
     }
 

--- a/views/css/usage.css
+++ b/views/css/usage.css
@@ -25,3 +25,13 @@
 .usage-data-container .results-list .grid-row.pagination {
     width: 100%;
 }
+
+.section-container .content-block .usage-data-container .usage-grid .datatable-wrapper .filter .icon-find {
+    padding: 0 !important;
+    opacity: 1;
+    cursor: pointer;
+}
+
+.section-container .content-block .usage-data-container .usage-grid .datatable-wrapper .filter .icon-find:before {
+    color: #333;
+}

--- a/views/js/controller/Usage/index.js
+++ b/views/js/controller/Usage/index.js
@@ -79,13 +79,25 @@ define([
             },
             {
                 id: 'publicationTime',
-                label: __('Last modified on'),
+                label: __('Published on'),
                 sortable: true
             }
         ];
     }
 
+    function getModeSettings(mode) {
+        return {
+            filter: mode !== 'delivery',
+            paginationStrategyTop: 'none',
+            paginationStrategyBottom: mode === 'delivery' ? 'none' : 'simple',
+            sortby: mode === 'delivery' ? 'label' : 'publicationTime',
+            sortorder: mode === 'delivery' ? 'asc' : 'desc'
+        };
+    }
+
     return {
+        getModeSettings: getModeSettings,
+        getColumns: getColumns,
         start: function start() {
             const urlInfo = url.parse(window.location);
             const $grid = $('.usage-grid');
@@ -137,21 +149,16 @@ define([
                 }
             ];
 
-            $grid.datatable({
+            $grid.datatable(Object.assign({
                 url: dataUrl,
-                filter: true,
                 labels: {
                     filter: mode === 'delivery' ? __('Search Tests') : __('Search Deliveries'),
                     title: mode === 'delivery' ? __('Search Tests') : __('Search Deliveries')
                 },
                 model: getColumns(mode),
-                paginationStrategyTop: 'none',
-                paginationStrategyBottom: 'simple',
                 rows: getNumRows(),
-                sortby: mode === 'delivery' ? 'label' : 'publicationTime',
-                sortorder: mode === 'delivery' ? 'asc' : 'desc',
                 actions: actions
-            });
+            }, getModeSettings(mode)));
         }
     };
 });

--- a/views/js/test/controller/Usage/test.html
+++ b/views/js/test/controller/Usage/test.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Test - Usage controller</title>
+        <base href="../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="controller/Usage/index.js"></script>
+        <script type="text/javascript">
+
+            QUnit.config.autostart = false;
+
+            require(['/tao/ClientConfig/config'], function () {
+                require(['taoDeliveryRdf/test/controller/Usage/test'], function () {
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/controller/Usage/test.js
+++ b/views/js/test/controller/Usage/test.js
@@ -1,0 +1,68 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+define([
+    'taoDeliveryRdf/controller/Usage/index'
+], function (usageController) {
+    'use strict';
+
+    QUnit.module('Usage controller');
+
+    QUnit.test('module', function (assert) {
+        assert.expect(3);
+        assert.equal(typeof usageController, 'object', 'The Usage controller exposes an object');
+        assert.equal(typeof usageController.getModeSettings, 'function', 'The controller exposes getModeSettings');
+        assert.equal(typeof usageController.getColumns, 'function', 'The controller exposes getColumns');
+    });
+
+    QUnit.test('delivery mode disables search and pagination', function (assert) {
+        assert.expect(5);
+
+        const settings = usageController.getModeSettings('delivery');
+
+        assert.strictEqual(settings.filter, false, 'Search filter is disabled');
+        assert.strictEqual(settings.paginationStrategyTop, 'none', 'Top pagination is hidden');
+        assert.strictEqual(settings.paginationStrategyBottom, 'none', 'Bottom pagination is hidden');
+        assert.strictEqual(settings.sortby, 'label', 'Default sort is label');
+        assert.strictEqual(settings.sortorder, 'asc', 'Default sort order is ascending');
+    });
+
+    QUnit.test('test mode enables search and pagination', function (assert) {
+        assert.expect(5);
+
+        const settings = usageController.getModeSettings('test');
+
+        assert.strictEqual(settings.filter, true, 'Search filter is enabled');
+        assert.strictEqual(settings.paginationStrategyTop, 'none', 'Top pagination is hidden');
+        assert.strictEqual(settings.paginationStrategyBottom, 'simple', 'Bottom pagination is enabled');
+        assert.strictEqual(settings.sortby, 'publicationTime', 'Default sort is publication time');
+        assert.strictEqual(settings.sortorder, 'desc', 'Default sort order is descending');
+    });
+
+    QUnit.test('columns depend on mode', function (assert) {
+        assert.expect(4);
+
+        const deliveryColumns = usageController.getColumns('delivery');
+        const testColumns = usageController.getColumns('test');
+
+        assert.strictEqual(deliveryColumns.length, 2, 'Delivery usage has two columns');
+        assert.strictEqual(deliveryColumns[1].sortable, false, 'Delivery location is not sortable');
+
+        assert.strictEqual(testColumns.length, 3, 'Test usage has three columns');
+        assert.strictEqual(testColumns[1].sortable, true, 'Test location is sortable');
+    });
+});

--- a/views/js/test/controller/Usage/test.js
+++ b/views/js/test/controller/Usage/test.js
@@ -65,4 +65,26 @@ define([
         assert.strictEqual(testColumns.length, 3, 'Test usage has three columns');
         assert.strictEqual(testColumns[1].sortable, true, 'Test location is sortable');
     });
+
+    QUnit.test('unsupported mode falls back to test settings and columns', function (assert) {
+        assert.expect(2);
+
+        const testSettings = usageController.getModeSettings('test');
+        const unsupportedSettings = usageController.getModeSettings('unsupported');
+
+        assert.deepEqual(
+            unsupportedSettings,
+            testSettings,
+            'Unknown mode uses the same datatable settings as test mode'
+        );
+
+        const testColumns = usageController.getColumns('test');
+        const unsupportedColumns = usageController.getColumns('unsupported');
+
+        assert.deepEqual(
+            unsupportedColumns,
+            testColumns,
+            'Unknown mode uses the same column model as test mode'
+        );
+    });
 });


### PR DESCRIPTION
Summary
Fixes the Usage tab UI for deliveries and tests, and adds tests for the new behavior.

Delivery usage: Hides search and bottom pagination (at most one source test).
Test usage: Keeps search and pagination for the deliveries list.
Search icon: Restores active look and pointer cursor on “Search Deliveries” (overrides global opacity: 0.5 / cursor: default).
Published on: Column label set to “Published on”; dates formatted with tao_helpers_Date::displayeDate().
Translations: Adds missing en-US strings for the usage screens (titles, columns, search placeholders, View action).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode-specific table settings for deliveries vs tests (different filtering, pagination, and default sorting).

* **UI/UX Improvements**
  * Publication time label changed to "Published on" and dates now use localized display.
  * Filter icon styling improved for clearer interaction.

* **Localization**
  * Added new translatable strings for delivery/test labels, location, search, usage, and view.

* **Tests**
  * Added unit and QUnit tests covering mode settings, column sets, and filter-query behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-delivery-rdf/pull/524)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->